### PR TITLE
Add YAML-driven run setup skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.venv/
+venv/
+build/
+dist/
+*.egg-info/
+outputs/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
 # NEFAS - Natural Ecosystem Flood Attenuation Simulator
 
 NEFAS is a reduced-complexity 2D flood simulation model for evaluating how wetlands, floodplains, forests, and other natural landscapes slow, store, and attenuate floodwaters.
+
+## Run Setup
+
+Install the project in editable mode:
+
+```powershell
+python -m pip install -e .
+```
+
+Prepare a model run from a YAML configuration:
+
+```powershell
+python run_model.py examples/minimal_config.yaml
+```
+
+The initial entry point validates the configuration shape, creates the configured output directory, logs setup progress, and exits without running a simulation.

--- a/README.md
+++ b/README.md
@@ -15,5 +15,3 @@ Prepare a model run from a YAML configuration:
 ```powershell
 python run_model.py examples/minimal_config.yaml
 ```
-
-The initial entry point validates the configuration shape, creates the configured output directory, logs setup progress, and exits without running a simulation.

--- a/examples/minimal_config.yaml
+++ b/examples/minimal_config.yaml
@@ -1,0 +1,26 @@
+inputs:
+  dem: data/dem.tif
+  area_of_interest: data/area_of_interest.geojson
+  storm_footprint: data/storm_footprint.geojson
+
+rainfall:
+  series:
+    - time_minutes: 0
+      rate_mm_per_hr: 0
+    - time_minutes: 15
+      rate_mm_per_hr: 10
+    - time_minutes: 30
+      rate_mm_per_hr: 30
+    - time_minutes: 45
+      rate_mm_per_hr: 60
+    - time_minutes: 60
+      rate_mm_per_hr: 25
+    - time_minutes: 90
+      rate_mm_per_hr: 5
+
+time_step:
+  seconds: 5
+  max_seconds: 30
+
+output:
+  directory: outputs/example

--- a/examples/minimal_config.yaml
+++ b/examples/minimal_config.yaml
@@ -1,7 +1,7 @@
 inputs:
   dem: data/dem.tif
-  area_of_interest: data/area_of_interest.geojson
-  storm_footprint: data/storm_footprint.geojson
+  area_of_interest: data/area_of_interest.gpkg
+  storm_footprint: data/storm_footprint.gpkg
 
 rainfall:
   series:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "nefas"
+version = "0.1.0"
+description = "Natural Ecosystem Flood Attenuation Simulator"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "PyYAML>=6.0",
+    "tqdm>=4.66",
+]
+
+[project.scripts]
+nefas-run = "nefas.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/run_model.py
+++ b/run_model.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent / "src"))
+from nefas.cli import main
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/run_model.py
+++ b/run_model.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
 import sys
-from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parent / "src"))
 from nefas.cli import main
 
 

--- a/src/nefas/__init__.py
+++ b/src/nefas/__init__.py
@@ -1,5 +1,1 @@
 """Natural Ecosystem Flood Attenuation Simulator."""
-
-__all__ = ["__version__"]
-
-__version__ = "0.1.0"

--- a/src/nefas/__init__.py
+++ b/src/nefas/__init__.py
@@ -1,0 +1,5 @@
+"""Natural Ecosystem Flood Attenuation Simulator."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/src/nefas/cli.py
+++ b/src/nefas/cli.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+
+from .config import ConfigError
+from .logging import configure_logging
+from .runner import prepare_run
+
+LOGGER = logging.getLogger(__name__)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Prepare a NEFAS flood simulation run.")
+    parser.add_argument("config", type=Path, help="Path to the simulation YAML file.")
+    parser.add_argument("--verbose", action="store_true", help="Enable debug logging.")
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    configure_logging(verbose=args.verbose)
+
+    try:
+        prepare_run(args.config)
+    except (ConfigError, OSError, RuntimeError) as exc:
+        LOGGER.error("%s", exc)
+        return 1
+
+    LOGGER.info("Configuration is valid. No simulation was run.")
+    return 0

--- a/src/nefas/config.py
+++ b/src/nefas/config.py
@@ -73,8 +73,8 @@ def parse_config(raw: Any) -> SimulationConfig:
         ),
         rainfall=RainfallConfig(series=_rainfall_series(rainfall)),
         time_step=TimeStepConfig(
-            seconds=_positive_number(time_step, "seconds"),
-            max_seconds=_optional_positive_number(time_step, "max_seconds"),
+            seconds=_float(time_step, "seconds", positive=True),
+            max_seconds=_optional_float(time_step, "max_seconds", positive=True),
         ),
         output=OutputConfig(directory=_path(output, "directory")),
     )
@@ -103,36 +103,28 @@ def _rainfall_series(section: dict[str, Any]) -> tuple[RainfallPoint, ...]:
         point = _mapping(item, f"rainfall.series[{index}]")
         points.append(
             RainfallPoint(
-                time_minutes=_non_negative_number(point, "time_minutes"),
-                rate_mm_per_hr=_non_negative_number(point, "rate_mm_per_hr"),
+                time_minutes=_float(point, "time_minutes"),
+                rate_mm_per_hr=_float(point, "rate_mm_per_hr"),
             )
         )
 
     return tuple(points)
 
 
-def _optional_positive_number(section: dict[str, Any], key: str) -> float | None:
+def _optional_float(section: dict[str, Any], key: str, *, positive: bool = False) -> float | None:
     if key not in section or section[key] is None:
         return None
-    return _positive_number(section, key)
+    return _float(section, key, positive=positive)
 
 
-def _positive_number(section: dict[str, Any], key: str) -> float:
-    value = _number(section, key)
-    if value <= 0:
+def _float(section: dict[str, Any], key: str, *, positive: bool = False) -> float:
+    try:
+        value = float(section[key])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ConfigError(f"{key} must be numeric.") from exc
+
+    if positive and value <= 0:
         raise ConfigError(f"{key} must be greater than zero.")
-    return value
-
-
-def _non_negative_number(section: dict[str, Any], key: str) -> float:
-    value = _number(section, key)
-    if value < 0:
+    if not positive and value < 0:
         raise ConfigError(f"{key} must be zero or greater.")
     return value
-
-
-def _number(section: dict[str, Any], key: str) -> float:
-    value = section.get(key)
-    if not isinstance(value, int | float):
-        raise ConfigError(f"{key} must be numeric.")
-    return float(value)

--- a/src/nefas/config.py
+++ b/src/nefas/config.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+class ConfigError(ValueError):
+    """Raised when a simulation configuration does not match the schema."""
+
+
+@dataclass(frozen=True)
+class InputConfig:
+    dem: Path
+    area_of_interest: Path
+    storm_footprint: Path
+
+
+@dataclass(frozen=True)
+class RainfallPoint:
+    time_minutes: float
+    rate_mm_per_hr: float
+
+
+@dataclass(frozen=True)
+class RainfallConfig:
+    series: tuple[RainfallPoint, ...]
+
+
+@dataclass(frozen=True)
+class TimeStepConfig:
+    seconds: float
+    max_seconds: float | None = None
+
+
+@dataclass(frozen=True)
+class OutputConfig:
+    directory: Path
+
+
+@dataclass(frozen=True)
+class SimulationConfig:
+    inputs: InputConfig
+    rainfall: RainfallConfig
+    time_step: TimeStepConfig
+    output: OutputConfig
+
+
+def load_config(path: Path) -> SimulationConfig:
+    try:
+        import yaml
+    except ImportError as exc:
+        raise RuntimeError("PyYAML is required to read simulation configuration files.") from exc
+
+    with path.open("r", encoding="utf-8") as stream:
+        raw = yaml.safe_load(stream)
+
+    return parse_config(raw)
+
+
+def parse_config(raw: Any) -> SimulationConfig:
+    root = _mapping(raw, "configuration")
+    inputs = _mapping(root.get("inputs"), "inputs")
+    rainfall = _mapping(root.get("rainfall"), "rainfall")
+    time_step = _mapping(root.get("time_step"), "time_step")
+    output = _mapping(root.get("output"), "output")
+
+    return SimulationConfig(
+        inputs=InputConfig(
+            dem=_path(inputs, "dem"),
+            area_of_interest=_path(inputs, "area_of_interest"),
+            storm_footprint=_path(inputs, "storm_footprint"),
+        ),
+        rainfall=RainfallConfig(series=_rainfall_series(rainfall)),
+        time_step=TimeStepConfig(
+            seconds=_positive_number(time_step, "seconds"),
+            max_seconds=_optional_positive_number(time_step, "max_seconds"),
+        ),
+        output=OutputConfig(directory=_path(output, "directory")),
+    )
+
+
+def _mapping(value: Any, name: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ConfigError(f"{name} must be a mapping.")
+    return value
+
+
+def _path(section: dict[str, Any], key: str) -> Path:
+    value = section.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ConfigError(f"{key} must be a non-empty path string.")
+    return Path(value)
+
+
+def _rainfall_series(section: dict[str, Any]) -> tuple[RainfallPoint, ...]:
+    series = section.get("series")
+    if not isinstance(series, list) or not series:
+        raise ConfigError("rainfall.series must be a non-empty list.")
+
+    points: list[RainfallPoint] = []
+    for index, item in enumerate(series):
+        point = _mapping(item, f"rainfall.series[{index}]")
+        points.append(
+            RainfallPoint(
+                time_minutes=_non_negative_number(point, "time_minutes"),
+                rate_mm_per_hr=_non_negative_number(point, "rate_mm_per_hr"),
+            )
+        )
+
+    return tuple(points)
+
+
+def _optional_positive_number(section: dict[str, Any], key: str) -> float | None:
+    if key not in section or section[key] is None:
+        return None
+    return _positive_number(section, key)
+
+
+def _positive_number(section: dict[str, Any], key: str) -> float:
+    value = _number(section, key)
+    if value <= 0:
+        raise ConfigError(f"{key} must be greater than zero.")
+    return value
+
+
+def _non_negative_number(section: dict[str, Any], key: str) -> float:
+    value = _number(section, key)
+    if value < 0:
+        raise ConfigError(f"{key} must be zero or greater.")
+    return value
+
+
+def _number(section: dict[str, Any], key: str) -> float:
+    value = section.get(key)
+    if not isinstance(value, int | float):
+        raise ConfigError(f"{key} must be numeric.")
+    return float(value)

--- a/src/nefas/logging.py
+++ b/src/nefas/logging.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import logging
+import sys
+
+
+def configure_logging(verbose: bool = False) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+        stream=sys.stderr,
+        force=True,
+    )

--- a/src/nefas/runner.py
+++ b/src/nefas/runner.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+from .config import SimulationConfig, load_config
+
+LOGGER = logging.getLogger(__name__)
+
+
+def prepare_run(config_path: Path) -> SimulationConfig:
+    try:
+        from tqdm import tqdm
+    except ImportError as exc:
+        raise RuntimeError("tqdm is required for progress reporting.") from exc
+
+    steps = ("load configuration", "prepare output directory")
+    with tqdm(steps, desc="Preparing run", unit="step", disable=not sys.stderr.isatty()) as progress:
+        config = load_config(config_path)
+        LOGGER.info("Loaded configuration from %s", config_path)
+        progress.update()
+
+        config.output.directory.mkdir(parents=True, exist_ok=True)
+        LOGGER.info("Output directory is ready at %s", config.output.directory)
+        progress.update()
+
+    return config

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,8 +12,8 @@ class ConfigParsingTests(unittest.TestCase):
             {
                 "inputs": {
                     "dem": "data/dem.tif",
-                    "area_of_interest": "data/aoi.geojson",
-                    "storm_footprint": "data/storm.geojson",
+                    "area_of_interest": "data/aoi.gpkg",
+                    "storm_footprint": "data/storm.gpkg",
                 },
                 "rainfall": {
                     "series": [
@@ -37,8 +37,8 @@ class ConfigParsingTests(unittest.TestCase):
                 {
                     "inputs": {
                         "dem": "data/dem.tif",
-                        "area_of_interest": "data/aoi.geojson",
-                        "storm_footprint": "data/storm.geojson",
+                        "area_of_interest": "data/aoi.gpkg",
+                        "storm_footprint": "data/storm.gpkg",
                     },
                     "rainfall": {"series": []},
                     "time_step": {"seconds": 5},

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from nefas.config import ConfigError, parse_config
+
+
+class ConfigParsingTests(unittest.TestCase):
+    def test_parses_minimal_configuration(self) -> None:
+        config = parse_config(
+            {
+                "inputs": {
+                    "dem": "data/dem.tif",
+                    "area_of_interest": "data/aoi.geojson",
+                    "storm_footprint": "data/storm.geojson",
+                },
+                "rainfall": {
+                    "series": [
+                        {"time_minutes": 0, "rate_mm_per_hr": 0},
+                        {"time_minutes": 15, "rate_mm_per_hr": 25},
+                    ]
+                },
+                "time_step": {"seconds": 5},
+                "output": {"directory": "outputs/example"},
+            }
+        )
+
+        self.assertEqual(config.inputs.dem, Path("data/dem.tif"))
+        self.assertEqual(config.rainfall.series[1].rate_mm_per_hr, 25)
+        self.assertEqual(config.time_step.seconds, 5)
+        self.assertEqual(config.output.directory, Path("outputs/example"))
+
+    def test_requires_rainfall_series(self) -> None:
+        with self.assertRaises(ConfigError):
+            parse_config(
+                {
+                    "inputs": {
+                        "dem": "data/dem.tif",
+                        "area_of_interest": "data/aoi.geojson",
+                        "storm_footprint": "data/storm.geojson",
+                    },
+                    "rainfall": {"series": []},
+                    "time_step": {"seconds": 5},
+                    "output": {"directory": "outputs/example"},
+                }
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a minimal Python package skeleton for NEFAS
- add `run_model.py` and `nefas-run` entry points for YAML-driven setup
- validate the configuration shape for inputs, rainfall series, timestep settings, and output directory
- create the configured output directory and exit before any simulation work
- add an example configuration and parser tests

## Validation
- `python -m unittest discover -s tests`
- `python -m compileall src tests run_model.py`
- `python run_model.py examples/minimal_config.yaml`

Closes #1