### PR TITLE
Add AOI filtering and DEM clipping preprocessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,3 @@ Prepare a model run from a YAML configuration:
 ```powershell
 python run_model.py examples/minimal_config.yaml
 ```
-
-The setup step writes geospatial intermediates beneath the configured output directory, using the configuration file name as the workspace name. For example, `configs/united_states.yaml` writes to `outputs/united_states/`.

--- a/README.md
+++ b/README.md
@@ -15,3 +15,5 @@ Prepare a model run from a YAML configuration:
 ```powershell
 python run_model.py examples/minimal_config.yaml
 ```
+
+The setup step writes geospatial intermediates beneath the configured output directory, using the configuration file name as the workspace name. For example, `configs/united_states.yaml` writes to `outputs/united_states/`.

--- a/examples/minimal_config.yaml
+++ b/examples/minimal_config.yaml
@@ -24,3 +24,8 @@ time_step:
 
 output:
   directory: outputs/example
+
+processing:
+  area_of_interest:
+    filters:
+      name: United States

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,9 @@ description = "Natural Ecosystem Flood Attenuation Simulator"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
+    "geopandas>=0.14",
     "PyYAML>=6.0",
+    "rasterio>=1.3",
     "tqdm>=4.66",
 ]
 

--- a/src/nefas/cli.py
+++ b/src/nefas/cli.py
@@ -29,5 +29,5 @@ def main() -> int:
         LOGGER.error("%s", exc)
         return 1
 
-    LOGGER.info("Configuration is valid. No simulation was run.")
+    LOGGER.info("Input preprocessing is complete. No simulation was run.")
     return 0

--- a/src/nefas/config.py
+++ b/src/nefas/config.py
@@ -39,11 +39,22 @@ class OutputConfig:
 
 
 @dataclass(frozen=True)
+class AreaOfInterestProcessingConfig:
+    filters: dict[str, str | int | float | bool]
+
+
+@dataclass(frozen=True)
+class ProcessingConfig:
+    area_of_interest: AreaOfInterestProcessingConfig
+
+
+@dataclass(frozen=True)
 class SimulationConfig:
     inputs: InputConfig
     rainfall: RainfallConfig
     time_step: TimeStepConfig
     output: OutputConfig
+    processing: ProcessingConfig
 
 
 def load_config(path: Path) -> SimulationConfig:
@@ -64,6 +75,7 @@ def parse_config(raw: Any) -> SimulationConfig:
     rainfall = _mapping(root.get("rainfall"), "rainfall")
     time_step = _mapping(root.get("time_step"), "time_step")
     output = _mapping(root.get("output"), "output")
+    processing = _optional_mapping(root.get("processing"), "processing")
 
     return SimulationConfig(
         inputs=InputConfig(
@@ -77,6 +89,11 @@ def parse_config(raw: Any) -> SimulationConfig:
             max_seconds=_optional_float(time_step, "max_seconds", positive=True),
         ),
         output=OutputConfig(directory=_path(output, "directory")),
+        processing=ProcessingConfig(
+            area_of_interest=AreaOfInterestProcessingConfig(
+                filters=_area_of_interest_filters(processing)
+            )
+        ),
     )
 
 
@@ -86,11 +103,33 @@ def _mapping(value: Any, name: str) -> dict[str, Any]:
     return value
 
 
+def _optional_mapping(value: Any, name: str) -> dict[str, Any]:
+    if value is None:
+        return {}
+    return _mapping(value, name)
+
+
 def _path(section: dict[str, Any], key: str) -> Path:
     value = section.get(key)
     if not isinstance(value, str) or not value.strip():
         raise ConfigError(f"{key} must be a non-empty path string.")
     return Path(value)
+
+
+def _area_of_interest_filters(section: dict[str, Any]) -> dict[str, str | int | float | bool]:
+    area_of_interest = _optional_mapping(section.get("area_of_interest"), "processing.area_of_interest")
+    filters = area_of_interest.get("filters", {})
+    if filters is None:
+        return {}
+    filters = _mapping(filters, "processing.area_of_interest.filters")
+
+    for key, value in filters.items():
+        if not isinstance(key, str) or not key.strip():
+            raise ConfigError("AOI filter names must be non-empty strings.")
+        if not isinstance(value, str | int | float | bool):
+            raise ConfigError(f"AOI filter {key} must be a scalar value.")
+
+    return filters
 
 
 def _rainfall_series(section: dict[str, Any]) -> tuple[RainfallPoint, ...]:

--- a/src/nefas/config.py
+++ b/src/nefas/config.py
@@ -75,7 +75,8 @@ def parse_config(raw: Any) -> SimulationConfig:
     rainfall = _mapping(root.get("rainfall"), "rainfall")
     time_step = _mapping(root.get("time_step"), "time_step")
     output = _mapping(root.get("output"), "output")
-    processing = _optional_mapping(root.get("processing"), "processing")
+    processing = root.get("processing") or {}
+    processing = _mapping(processing, "processing")
 
     return SimulationConfig(
         inputs=InputConfig(
@@ -103,12 +104,6 @@ def _mapping(value: Any, name: str) -> dict[str, Any]:
     return value
 
 
-def _optional_mapping(value: Any, name: str) -> dict[str, Any]:
-    if value is None:
-        return {}
-    return _mapping(value, name)
-
-
 def _path(section: dict[str, Any], key: str) -> Path:
     value = section.get(key)
     if not isinstance(value, str) or not value.strip():
@@ -117,11 +112,8 @@ def _path(section: dict[str, Any], key: str) -> Path:
 
 
 def _area_of_interest_filters(section: dict[str, Any]) -> dict[str, str | int | float | bool]:
-    area_of_interest = _optional_mapping(section.get("area_of_interest"), "processing.area_of_interest")
-    filters = area_of_interest.get("filters", {})
-    if filters is None:
-        return {}
-    filters = _mapping(filters, "processing.area_of_interest.filters")
+    area_of_interest = section.get("area_of_interest") or {}
+    filters = area_of_interest.get("filters") or {}
 
     for key, value in filters.items():
         if not isinstance(key, str) or not key.strip():

--- a/src/nefas/preprocessing.py
+++ b/src/nefas/preprocessing.py
@@ -5,6 +5,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+import geopandas as gpd
+import rasterio
+from rasterio.mask import mask
+
 from .config import SimulationConfig
 
 LOGGER = logging.getLogger(__name__)
@@ -23,13 +27,6 @@ def intermediate_workspace(config_path: Path, output_directory: Path) -> Path:
 
 
 def prepare_intermediates(config: SimulationConfig, config_path: Path) -> IntermediateOutputs:
-    try:
-        import geopandas as gpd
-        import rasterio
-        from rasterio.mask import mask
-    except ImportError as exc:
-        raise RuntimeError("geopandas and rasterio are required for input preprocessing.") from exc
-
     workspace = intermediate_workspace(config_path, config.output.directory)
     workspace.mkdir(parents=True, exist_ok=True)
 

--- a/src/nefas/preprocessing.py
+++ b/src/nefas/preprocessing.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .config import SimulationConfig
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class IntermediateOutputs:
+    workspace: Path
+    selected_aoi: Path
+    projected_aoi: Path
+    clipped_dem: Path
+
+
+def intermediate_workspace(config_path: Path, output_directory: Path) -> Path:
+    return output_directory / config_path.stem
+
+
+def prepare_intermediates(config: SimulationConfig, config_path: Path) -> IntermediateOutputs:
+    try:
+        import geopandas as gpd
+        import rasterio
+        from rasterio.mask import mask
+    except ImportError as exc:
+        raise RuntimeError("geopandas and rasterio are required for input preprocessing.") from exc
+
+    workspace = intermediate_workspace(config_path, config.output.directory)
+    workspace.mkdir(parents=True, exist_ok=True)
+
+    selected_aoi_path = workspace / "aoi_selected.gpkg"
+    projected_aoi_path = workspace / "aoi_dem_crs.gpkg"
+    clipped_dem_path = workspace / "dem_clipped.tif"
+
+    LOGGER.info("Reading AOI from %s", config.inputs.area_of_interest)
+    area_of_interest = gpd.read_file(config.inputs.area_of_interest, fid_as_index=True)
+    selected_aoi = filter_area_of_interest(
+        area_of_interest,
+        config.processing.area_of_interest.filters,
+    )
+    if selected_aoi.empty:
+        raise RuntimeError("AOI filters did not select any features.")
+    selected_aoi.to_file(selected_aoi_path, driver="GPKG")
+    LOGGER.info("Wrote selected AOI features to %s", selected_aoi_path)
+
+    with rasterio.open(config.inputs.dem) as dem:
+        LOGGER.info("Reading DEM from %s", config.inputs.dem)
+        projected_aoi = selected_aoi.to_crs(dem.crs)
+        projected_aoi.to_file(projected_aoi_path, driver="GPKG")
+        LOGGER.info("Wrote DEM-projected AOI features to %s", projected_aoi_path)
+
+        clipped, transform = mask(dem, projected_aoi.geometry, crop=True)
+        profile = dem.profile.copy()
+        if not profile.get("tiled"):
+            profile.pop("blockxsize", None)
+            profile.pop("blockysize", None)
+        profile.update(
+            driver="GTiff",
+            height=clipped.shape[1],
+            width=clipped.shape[2],
+            transform=transform,
+        )
+
+    with rasterio.open(clipped_dem_path, "w", **profile) as output:
+        output.write(clipped)
+    LOGGER.info("Wrote clipped DEM to %s", clipped_dem_path)
+
+    return IntermediateOutputs(
+        workspace=workspace,
+        selected_aoi=selected_aoi_path,
+        projected_aoi=projected_aoi_path,
+        clipped_dem=clipped_dem_path,
+    )
+
+
+def filter_area_of_interest(area_of_interest: Any, filters: dict[str, str | int | float | bool]) -> Any:
+    selected = area_of_interest
+    for field, expected in filters.items():
+        if field in selected.columns:
+            selected = selected[selected[field] == expected]
+        elif field.lower() == "fid":
+            selected = selected[selected.index == expected]
+        else:
+            selected = selected.iloc[0:0]
+    return selected

--- a/src/nefas/runner.py
+++ b/src/nefas/runner.py
@@ -5,6 +5,7 @@ import sys
 from pathlib import Path
 
 from .config import SimulationConfig, load_config
+from .preprocessing import prepare_intermediates
 
 LOGGER = logging.getLogger(__name__)
 
@@ -15,7 +16,11 @@ def prepare_run(config_path: Path) -> SimulationConfig:
     except ImportError as exc:
         raise RuntimeError("tqdm is required for progress reporting.") from exc
 
-    steps = ("load configuration", "prepare output directory")
+    steps = (
+        "load configuration",
+        "prepare output directory",
+        "prepare geospatial intermediates",
+    )
     with tqdm(steps, desc="Preparing run", unit="step", disable=not sys.stderr.isatty()) as progress:
         config = load_config(config_path)
         LOGGER.info("Loaded configuration from %s", config_path)
@@ -23,6 +28,10 @@ def prepare_run(config_path: Path) -> SimulationConfig:
 
         config.output.directory.mkdir(parents=True, exist_ok=True)
         LOGGER.info("Output directory is ready at %s", config.output.directory)
+        progress.update()
+
+        intermediates = prepare_intermediates(config, config_path)
+        LOGGER.info("Intermediate workspace is ready at %s", intermediates.workspace)
         progress.update()
 
     return config

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -23,6 +23,14 @@ class ConfigParsingTests(unittest.TestCase):
                 },
                 "time_step": {"seconds": 5},
                 "output": {"directory": "outputs/example"},
+                "processing": {
+                    "area_of_interest": {
+                        "filters": {
+                            "name": "United States",
+                            "FID": 3283,
+                        }
+                    }
+                },
             }
         )
 
@@ -30,6 +38,30 @@ class ConfigParsingTests(unittest.TestCase):
         self.assertEqual(config.rainfall.series[1].rate_mm_per_hr, 25)
         self.assertEqual(config.time_step.seconds, 5)
         self.assertEqual(config.output.directory, Path("outputs/example"))
+        self.assertEqual(
+            config.processing.area_of_interest.filters,
+            {"name": "United States", "FID": 3283},
+        )
+
+    def test_aoi_filters_are_optional(self) -> None:
+        config = parse_config(
+            {
+                "inputs": {
+                    "dem": "data/dem.tif",
+                    "area_of_interest": "data/aoi.gpkg",
+                    "storm_footprint": "data/storm.gpkg",
+                },
+                "rainfall": {
+                    "series": [
+                        {"time_minutes": 0, "rate_mm_per_hr": 0},
+                    ]
+                },
+                "time_step": {"seconds": 5},
+                "output": {"directory": "outputs/example"},
+            }
+        )
+
+        self.assertEqual(config.processing.area_of_interest.filters, {})
 
     def test_requires_rainfall_series(self) -> None:
         with self.assertRaises(ConfigError):

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from nefas.preprocessing import intermediate_workspace
+
+
+class PreprocessingTests(unittest.TestCase):
+    def test_intermediate_workspace_uses_config_file_name(self) -> None:
+        workspace = intermediate_workspace(
+            Path("configs/united_states.yaml"),
+            Path("outputs"),
+        )
+
+        self.assertEqual(workspace, Path("outputs/united_states"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add optional AOI feature filters to the YAML configuration
- add preprocessing to select AOI features, reproject them to the DEM CRS, and clip the DEM
- write selected AOI, DEM-projected AOI, and clipped DEM into a config-named intermediate workspace
- add geospatial dependencies and focused parser/workspace tests

## Validation
- `python -m unittest discover -s tests`
- `python -m compileall src tests run_model.py`
- generated-data smoke test filtering by `name`
- generated-data smoke test filtering by native `FID`

Closes #3