### PR TITLE
Add simulation grid and state structures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "geopandas>=0.14",
+    "numpy>=1.26",
     "PyYAML>=6.0",
     "rasterio>=1.3",
     "tqdm>=4.66",

--- a/src/nefas/simulation.py
+++ b/src/nefas/simulation.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import rasterio
+from numpy.typing import NDArray
+
+FloatArray = NDArray[np.float64]
+BoolArray = NDArray[np.bool_]
+
+
+@dataclass(frozen=True, slots=True)
+class RasterGrid:
+    elevation: FloatArray
+    dx: float
+    dy: float
+    transform: Any = None
+    crs: Any = None
+    active: BoolArray | None = None
+
+    def __post_init__(self) -> None:
+        elevation = np.asarray(self.elevation, dtype=np.float64)
+        object.__setattr__(self, "elevation", elevation)
+        if self.active is None:
+            object.__setattr__(self, "active", np.isfinite(elevation))
+        else:
+            object.__setattr__(self, "active", np.asarray(self.active, dtype=bool))
+
+    @property
+    def shape(self) -> tuple[int, int]:
+        return self.elevation.shape
+
+    @property
+    def ny(self) -> int:
+        return self.shape[0]
+
+    @property
+    def nx(self) -> int:
+        return self.shape[1]
+
+    @property
+    def x_face_shape(self) -> tuple[int, int]:
+        return self.ny, self.nx + 1
+
+    @property
+    def y_face_shape(self) -> tuple[int, int]:
+        return self.ny + 1, self.nx
+
+    @classmethod
+    def from_dem(cls, path: Path) -> RasterGrid:
+        with rasterio.open(path) as source:
+            elevation = source.read(1).astype(np.float64)
+            active = source.read_masks(1) > 0
+            if source.nodata is not None:
+                active &= elevation != source.nodata
+
+            return cls(
+                elevation=np.where(active, elevation, np.nan),
+                dx=abs(source.transform.a),
+                dy=abs(source.transform.e),
+                transform=source.transform,
+                crs=source.crs,
+                active=active,
+            )
+
+
+@dataclass(slots=True)
+class SurfaceFields:
+    manning_n: FloatArray
+    runoff_coefficient: FloatArray
+
+    @classmethod
+    def uniform(
+        cls,
+        grid: RasterGrid,
+        *,
+        manning_n: float,
+        runoff_coefficient: float,
+    ) -> SurfaceFields:
+        return cls(
+            manning_n=np.full(grid.shape, manning_n, dtype=np.float64),
+            runoff_coefficient=np.full(grid.shape, runoff_coefficient, dtype=np.float64),
+        )
+
+
+@dataclass(slots=True)
+class HydraulicState:
+    depth: FloatArray
+    qx: FloatArray
+    qy: FloatArray
+    time_seconds: float = 0.0
+
+    @classmethod
+    def dry(cls, grid: RasterGrid) -> HydraulicState:
+        return cls(
+            depth=np.zeros(grid.shape, dtype=np.float64),
+            qx=np.zeros(grid.x_face_shape, dtype=np.float64),
+            qy=np.zeros(grid.y_face_shape, dtype=np.float64),
+        )
+
+    def water_surface(self, grid: RasterGrid) -> FloatArray:
+        return grid.elevation + self.depth
+
+
+@dataclass(slots=True)
+class DiagnosticState:
+    arrival_time: FloatArray
+    max_depth: FloatArray
+    max_velocity: FloatArray
+    flood_duration: FloatArray
+
+    @classmethod
+    def initialize(cls, grid: RasterGrid) -> DiagnosticState:
+        return cls(
+            arrival_time=np.full(grid.shape, np.nan, dtype=np.float64),
+            max_depth=np.zeros(grid.shape, dtype=np.float64),
+            max_velocity=np.zeros(grid.shape, dtype=np.float64),
+            flood_duration=np.zeros(grid.shape, dtype=np.float64),
+        )
+
+
+@dataclass(slots=True)
+class SimulationState:
+    grid: RasterGrid
+    surface: SurfaceFields
+    hydraulic: HydraulicState
+    diagnostics: DiagnosticState
+
+    @classmethod
+    def dry(
+        cls,
+        grid: RasterGrid,
+        *,
+        manning_n: float,
+        runoff_coefficient: float,
+    ) -> SimulationState:
+        return cls(
+            grid=grid,
+            surface=SurfaceFields.uniform(
+                grid,
+                manning_n=manning_n,
+                runoff_coefficient=runoff_coefficient,
+            ),
+            hydraulic=HydraulicState.dry(grid),
+            diagnostics=DiagnosticState.initialize(grid),
+        )

--- a/src/nefas/simulation.py
+++ b/src/nefas/simulation.py
@@ -16,7 +16,7 @@ class RasterGrid:
     """Terrain grid used by the finite-volume solver.
 
     The simulation itself only needs the terrain elevations, cell spacing, and
-    active-cell mask. Geospatial metadata stays outside this object so the
+    valid-cell mask. Geospatial metadata stays outside this object so the
     numerical state remains focused on array calculations.
     """
 
@@ -27,16 +27,16 @@ class RasterGrid:
     # Cell height in the y direction, in meters.
     dy: float
     # True where the DEM has valid data and the solver should update cells.
-    active: BoolArray | None = None
+    valid_cells: BoolArray | None = None
 
     def __post_init__(self) -> None:
-        """Normalize elevation and active-mask arrays to solver dtypes."""
+        """Normalize elevation and valid-cell arrays to solver dtypes."""
         elevation = np.asarray(self.elevation, dtype=np.float64)
         object.__setattr__(self, "elevation", elevation)
-        if self.active is None:
-            object.__setattr__(self, "active", np.isfinite(elevation))
+        if self.valid_cells is None:
+            object.__setattr__(self, "valid_cells", np.isfinite(elevation))
         else:
-            object.__setattr__(self, "active", np.asarray(self.active, dtype=bool))
+            object.__setattr__(self, "valid_cells", np.asarray(self.valid_cells, dtype=bool))
 
     @property
     def shape(self) -> tuple[int, int]:
@@ -53,30 +53,20 @@ class RasterGrid:
         """Number of columns in the cell-centered grid."""
         return self.shape[1]
 
-    @property
-    def x_face_shape(self) -> tuple[int, int]:
-        """Shape for east-west face fluxes, including boundary faces."""
-        return self.ny, self.nx + 1
-
-    @property
-    def y_face_shape(self) -> tuple[int, int]:
-        """Shape for north-south face fluxes, including boundary faces."""
-        return self.ny + 1, self.nx
-
     @classmethod
     def from_dem(cls, path: Path) -> RasterGrid:
         """Build a terrain grid from the first band of a DEM raster."""
         with rasterio.open(path) as source:
             elevation = source.read(1).astype(np.float64)
-            active = source.read_masks(1) > 0
+            valid_cells = source.read_masks(1) > 0
             if source.nodata is not None:
-                active &= elevation != source.nodata
+                valid_cells &= elevation != source.nodata
 
             return cls(
-                elevation=np.where(active, elevation, np.nan),
+                elevation=np.where(valid_cells, elevation, np.nan),
                 dx=abs(source.transform.a),
                 dy=abs(source.transform.e),
-                active=active,
+                valid_cells=valid_cells,
             )
 
 
@@ -121,8 +111,8 @@ class HydraulicState:
         """Create a zero-depth, zero-flux hydraulic state for a grid."""
         return cls(
             depth=np.zeros(grid.shape, dtype=np.float64),
-            qx=np.zeros(grid.x_face_shape, dtype=np.float64),
-            qy=np.zeros(grid.y_face_shape, dtype=np.float64),
+            qx=np.zeros((grid.ny, grid.nx + 1), dtype=np.float64),
+            qy=np.zeros((grid.ny + 1, grid.nx), dtype=np.float64),
         )
 
     def water_surface(self, grid: RasterGrid) -> FloatArray:

--- a/src/nefas/simulation.py
+++ b/src/nefas/simulation.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
 import numpy as np
 import rasterio
@@ -14,14 +13,24 @@ BoolArray = NDArray[np.bool_]
 
 @dataclass(frozen=True, slots=True)
 class RasterGrid:
+    """Terrain grid used by the finite-volume solver.
+
+    The simulation itself only needs the terrain elevations, cell spacing, and
+    active-cell mask. Geospatial metadata stays outside this object so the
+    numerical state remains focused on array calculations.
+    """
+
+    # Terrain elevation at cell centers, in meters.
     elevation: FloatArray
+    # Cell width in the x direction, in meters.
     dx: float
+    # Cell height in the y direction, in meters.
     dy: float
-    transform: Any = None
-    crs: Any = None
+    # True where the DEM has valid data and the solver should update cells.
     active: BoolArray | None = None
 
     def __post_init__(self) -> None:
+        """Normalize elevation and active-mask arrays to solver dtypes."""
         elevation = np.asarray(self.elevation, dtype=np.float64)
         object.__setattr__(self, "elevation", elevation)
         if self.active is None:
@@ -31,26 +40,32 @@ class RasterGrid:
 
     @property
     def shape(self) -> tuple[int, int]:
+        """Cell-centered grid shape as ``(ny, nx)``."""
         return self.elevation.shape
 
     @property
     def ny(self) -> int:
+        """Number of rows in the cell-centered grid."""
         return self.shape[0]
 
     @property
     def nx(self) -> int:
+        """Number of columns in the cell-centered grid."""
         return self.shape[1]
 
     @property
     def x_face_shape(self) -> tuple[int, int]:
+        """Shape for east-west face fluxes, including boundary faces."""
         return self.ny, self.nx + 1
 
     @property
     def y_face_shape(self) -> tuple[int, int]:
+        """Shape for north-south face fluxes, including boundary faces."""
         return self.ny + 1, self.nx
 
     @classmethod
     def from_dem(cls, path: Path) -> RasterGrid:
+        """Build a terrain grid from the first band of a DEM raster."""
         with rasterio.open(path) as source:
             elevation = source.read(1).astype(np.float64)
             active = source.read_masks(1) > 0
@@ -61,25 +76,27 @@ class RasterGrid:
                 elevation=np.where(active, elevation, np.nan),
                 dx=abs(source.transform.a),
                 dy=abs(source.transform.e),
-                transform=source.transform,
-                crs=source.crs,
                 active=active,
             )
 
 
 @dataclass(slots=True)
 class SurfaceFields:
+    """Cell-centered surface parameters used by forcing and friction terms."""
+
+    # Manning roughness coefficient for each grid cell.
     manning_n: FloatArray
+    # Fraction of rainfall that becomes surface-water input for each cell.
     runoff_coefficient: FloatArray
 
     @classmethod
     def uniform(
         cls,
         grid: RasterGrid,
-        *,
         manning_n: float,
         runoff_coefficient: float,
     ) -> SurfaceFields:
+        """Create spatially uniform surface parameters over a grid."""
         return cls(
             manning_n=np.full(grid.shape, manning_n, dtype=np.float64),
             runoff_coefficient=np.full(grid.shape, runoff_coefficient, dtype=np.float64),
@@ -88,13 +105,20 @@ class SurfaceFields:
 
 @dataclass(slots=True)
 class HydraulicState:
+    """Time-varying hydraulic arrays for a local-inertial simulation."""
+
+    # Water depth at cell centers, in meters.
     depth: FloatArray
+    # East-west face discharge or unit flux, depending on solver convention.
     qx: FloatArray
+    # North-south face discharge or unit flux, depending on solver convention.
     qy: FloatArray
+    # Elapsed model time from the beginning of the event, in seconds.
     time_seconds: float = 0.0
 
     @classmethod
     def dry(cls, grid: RasterGrid) -> HydraulicState:
+        """Create a zero-depth, zero-flux hydraulic state for a grid."""
         return cls(
             depth=np.zeros(grid.shape, dtype=np.float64),
             qx=np.zeros(grid.x_face_shape, dtype=np.float64),
@@ -102,18 +126,26 @@ class HydraulicState:
         )
 
     def water_surface(self, grid: RasterGrid) -> FloatArray:
+        """Return water-surface elevation as terrain elevation plus depth."""
         return grid.elevation + self.depth
 
 
 @dataclass(slots=True)
 class DiagnosticState:
+    """Accumulated outputs tracked while the simulation advances."""
+
+    # First time each cell exceeds the configured arrival-depth threshold.
     arrival_time: FloatArray
+    # Maximum simulated water depth at each cell, in meters.
     max_depth: FloatArray
+    # Maximum simulated flow speed at each cell, in meters per second.
     max_velocity: FloatArray
+    # Total time each cell remains above the flood-depth threshold, in seconds.
     flood_duration: FloatArray
 
     @classmethod
     def initialize(cls, grid: RasterGrid) -> DiagnosticState:
+        """Create empty diagnostic arrays for a new simulation."""
         return cls(
             arrival_time=np.full(grid.shape, np.nan, dtype=np.float64),
             max_depth=np.zeros(grid.shape, dtype=np.float64),
@@ -124,6 +156,8 @@ class DiagnosticState:
 
 @dataclass(slots=True)
 class SimulationState:
+    """Complete in-memory state for one simulation run."""
+
     grid: RasterGrid
     surface: SurfaceFields
     hydraulic: HydraulicState
@@ -133,10 +167,10 @@ class SimulationState:
     def dry(
         cls,
         grid: RasterGrid,
-        *,
         manning_n: float,
         runoff_coefficient: float,
     ) -> SimulationState:
+        """Create a simulation state with dry hydraulics and empty diagnostics."""
         return cls(
             grid=grid,
             surface=SurfaceFields.uniform(

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -41,11 +41,9 @@ class RasterGridTests(unittest.TestCase):
             grid = RasterGrid.from_dem(path)
 
         self.assertEqual(grid.shape, (2, 3))
-        self.assertEqual(grid.x_face_shape, (2, 4))
-        self.assertEqual(grid.y_face_shape, (3, 3))
         self.assertEqual(grid.dx, 30)
         self.assertEqual(grid.dy, 30)
-        self.assertFalse(bool(grid.active[0, 2]))
+        self.assertFalse(bool(grid.valid_cells[0, 2]))
         self.assertTrue(np.isnan(grid.elevation[0, 2]))
 
 
@@ -71,8 +69,8 @@ class SimulationStateTests(unittest.TestCase):
         )
 
         self.assertEqual(state.hydraulic.depth.shape, grid.shape)
-        self.assertEqual(state.hydraulic.qx.shape, grid.x_face_shape)
-        self.assertEqual(state.hydraulic.qy.shape, grid.y_face_shape)
+        self.assertEqual(state.hydraulic.qx.shape, (grid.ny, grid.nx + 1))
+        self.assertEqual(state.hydraulic.qy.shape, (grid.ny + 1, grid.nx))
         self.assertEqual(state.diagnostics.arrival_time.shape, grid.shape)
         self.assertTrue(np.all(state.hydraulic.depth == 0))
         self.assertTrue(np.all(state.hydraulic.qx == 0))

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+import rasterio
+from rasterio.transform import from_origin
+
+from nefas.simulation import RasterGrid, SimulationState
+
+
+class RasterGridTests(unittest.TestCase):
+    def test_loads_grid_from_dem(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "dem.tif"
+            transform = from_origin(100, 200, 30, 30)
+            data = np.array(
+                [
+                    [1, 2, -9999],
+                    [3, 4, 5],
+                ],
+                dtype=np.float32,
+            )
+
+            with rasterio.open(
+                path,
+                "w",
+                driver="GTiff",
+                height=2,
+                width=3,
+                count=1,
+                dtype="float32",
+                crs="EPSG:5070",
+                transform=transform,
+                nodata=-9999,
+            ) as dataset:
+                dataset.write(data, 1)
+
+            grid = RasterGrid.from_dem(path)
+
+        self.assertEqual(grid.shape, (2, 3))
+        self.assertEqual(grid.x_face_shape, (2, 4))
+        self.assertEqual(grid.y_face_shape, (3, 3))
+        self.assertEqual(grid.dx, 30)
+        self.assertEqual(grid.dy, 30)
+        self.assertFalse(bool(grid.active[0, 2]))
+        self.assertTrue(np.isnan(grid.elevation[0, 2]))
+
+
+class SimulationStateTests(unittest.TestCase):
+    def test_dry_state_shapes_follow_grid(self) -> None:
+        grid = RasterGrid(
+            elevation=np.array(
+                [
+                    [10, 11, 12, 13],
+                    [9, 10, 11, 12],
+                    [8, 9, 10, 11],
+                ],
+                dtype=np.float64,
+            ),
+            dx=30,
+            dy=30,
+        )
+
+        state = SimulationState.dry(
+            grid,
+            manning_n=0.08,
+            runoff_coefficient=0.35,
+        )
+
+        self.assertEqual(state.hydraulic.depth.shape, grid.shape)
+        self.assertEqual(state.hydraulic.qx.shape, grid.x_face_shape)
+        self.assertEqual(state.hydraulic.qy.shape, grid.y_face_shape)
+        self.assertEqual(state.diagnostics.arrival_time.shape, grid.shape)
+        self.assertTrue(np.all(state.hydraulic.depth == 0))
+        self.assertTrue(np.all(state.hydraulic.qx == 0))
+        self.assertTrue(np.all(state.hydraulic.qy == 0))
+        self.assertTrue(np.all(state.surface.manning_n == 0.08))
+        self.assertTrue(np.all(state.surface.runoff_coefficient == 0.35))
+        self.assertTrue(np.all(np.isnan(state.diagnostics.arrival_time)))
+        np.testing.assert_array_equal(state.hydraulic.water_surface(grid), grid.elevation)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a `RasterGrid` structure for DEM-backed terrain, cell spacing, CRS/transform metadata, active-cell mask, and face-array shapes
- add surface parameter fields for Manning roughness and runoff coefficient
- add hydraulic state arrays for water depth, east-west face fluxes, north-south face fluxes, and simulation time
- add diagnostic arrays for arrival time, maximum depth, maximum velocity, and flood duration
- add dry-state constructors and focused tests for DEM loading and array shapes

## Validation
- `python -m compileall src tests run_model.py`
- `python -m unittest discover -s tests`

Closes #5