### PR TITLE
[codex] Add fixed snapshot depth scale

### DIFF
--- a/examples/minimal_config.yaml
+++ b/examples/minimal_config.yaml
@@ -27,6 +27,7 @@ output:
   snapshots:
     directory: snapshots
     interval_minutes: 15
+    max_depth_meters: 1.0
 
 processing:
   area_of_interest:

--- a/src/nefas/config.py
+++ b/src/nefas/config.py
@@ -39,6 +39,7 @@ class TimeStepConfig:
 class SnapshotConfig:
     directory: Path
     interval_minutes: float
+    max_depth_meters: float | None = None
 
 
 @dataclass(frozen=True)
@@ -137,6 +138,7 @@ def _snapshot_config(section: dict[str, Any]) -> SnapshotConfig:
     return SnapshotConfig(
         directory=Path(directory),
         interval_minutes=_float({"interval_minutes": interval_minutes}, "interval_minutes", positive=True),
+        max_depth_meters=_optional_float(snapshots, "max_depth_meters", positive=True),
     )
 
 

--- a/src/nefas/engine.py
+++ b/src/nefas/engine.py
@@ -58,6 +58,7 @@ def run_simulation(
             state,
             snapshot_directory,
             index=0,
+            max_depth_meters=config.output.snapshots.max_depth_meters,
         )
     ]
     next_snapshot_seconds = min(snapshot_interval_seconds, duration_seconds)
@@ -86,6 +87,7 @@ def run_simulation(
                         state,
                         snapshot_directory,
                         index=len(snapshots),
+                        max_depth_meters=config.output.snapshots.max_depth_meters,
                     )
                 )
                 progress.set_postfix(snapshots=len(snapshots))
@@ -429,6 +431,7 @@ def write_snapshot(
     state: SimulationState,
     snapshot_directory: Path,
     index: int,
+    max_depth_meters: float | None = None,
 ) -> Path:
     """Write one simulation snapshot and return its path."""
     snapshot = snapshot_directory / f"snapshot_{index:04d}.png"
@@ -438,6 +441,7 @@ def write_snapshot(
         state.hydraulic.depth,
         snapshot,
         elapsed_minutes=state.hydraulic.time_seconds / 60,
+        max_depth_meters=max_depth_meters,
     )
     return snapshot
 
@@ -448,6 +452,7 @@ def render_snapshot(
     depth: np.ndarray,
     path: Path,
     elapsed_minutes: float,
+    max_depth_meters: float | None = None,
 ) -> None:
     """Render DEM, storm footprint, and water depth into a PNG image."""
     figure, axis = plt.subplots(figsize=(8, 6), dpi=150)
@@ -455,7 +460,10 @@ def render_snapshot(
     axis.imshow(np.where(storm_mask, 1.0, np.nan), cmap="Blues", alpha=0.22, vmin=0, vmax=1)
 
     depth_layer = np.ma.masked_where(depth <= 0, depth)
-    water = axis.imshow(depth_layer, cmap="turbo", alpha=0.75)
+    depth_scale = {}
+    if max_depth_meters is not None:
+        depth_scale = {"vmin": 0, "vmax": max_depth_meters}
+    water = axis.imshow(depth_layer, cmap="turbo", alpha=0.75, **depth_scale)
     if np.nanmax(depth) > 0:
         colorbar = figure.colorbar(water, ax=axis, fraction=0.046, pad=0.04)
         colorbar.set_label("Water depth (m)")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,6 +27,7 @@ class ConfigParsingTests(unittest.TestCase):
                     "snapshots": {
                         "directory": "frames",
                         "interval_minutes": 10,
+                        "max_depth_meters": 1.5,
                     },
                 },
                 "processing": {
@@ -46,6 +47,7 @@ class ConfigParsingTests(unittest.TestCase):
         self.assertEqual(config.output.directory, Path("outputs/example"))
         self.assertEqual(config.output.snapshots.directory, Path("frames"))
         self.assertEqual(config.output.snapshots.interval_minutes, 10)
+        self.assertEqual(config.output.snapshots.max_depth_meters, 1.5)
         self.assertEqual(
             config.processing.area_of_interest.filters,
             {"name": "United States", "FID": 3283},
@@ -75,6 +77,7 @@ class ConfigParsingTests(unittest.TestCase):
             config.output.snapshots.interval_minutes,
             DEFAULT_SNAPSHOT_INTERVAL_MINUTES,
         )
+        self.assertIsNone(config.output.snapshots.max_depth_meters)
 
     def test_requires_rainfall_series(self) -> None:
         with self.assertRaises(ConfigError):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 
@@ -9,6 +11,7 @@ from nefas.engine import (
     add_rainfall_depth,
     apply_rainfall_forcing,
     rainfall_rate_m_per_second,
+    render_snapshot,
     timestep_duration_seconds,
     water_timestep,
 )
@@ -226,6 +229,55 @@ class EngineTests(unittest.TestCase):
         self.assertAlmostEqual(state.hydraulic.depth[0, 0], 0)
         self.assertAlmostEqual(state.hydraulic.depth[0, 1], 0.01)
         self.assertAlmostEqual(float(state.hydraulic.depth.sum()), 0.01)
+
+    def test_render_snapshot_uses_configured_depth_scale(self) -> None:
+        grid = RasterGrid(
+            elevation=np.zeros((1, 1), dtype=np.float64),
+            dx=30,
+            dy=30,
+        )
+        figure = MagicMock()
+        axis = MagicMock()
+        water_layer = MagicMock()
+        axis.imshow.side_effect = [MagicMock(), MagicMock(), water_layer]
+
+        with patch("nefas.engine.plt.subplots", return_value=(figure, axis)):
+            render_snapshot(
+                grid,
+                storm_mask=np.array([[True]]),
+                depth=np.array([[0.5]], dtype=np.float64),
+                path=Path("snapshot.png"),
+                elapsed_minutes=15,
+                max_depth_meters=2.0,
+            )
+
+        _, water_kwargs = axis.imshow.call_args_list[2]
+        self.assertEqual(water_kwargs["vmin"], 0)
+        self.assertEqual(water_kwargs["vmax"], 2.0)
+        figure.colorbar.assert_called_once_with(water_layer, ax=axis, fraction=0.046, pad=0.04)
+
+    def test_render_snapshot_autoscales_when_depth_scale_is_omitted(self) -> None:
+        grid = RasterGrid(
+            elevation=np.zeros((1, 1), dtype=np.float64),
+            dx=30,
+            dy=30,
+        )
+        figure = MagicMock()
+        axis = MagicMock()
+        axis.imshow.side_effect = [MagicMock(), MagicMock(), MagicMock()]
+
+        with patch("nefas.engine.plt.subplots", return_value=(figure, axis)):
+            render_snapshot(
+                grid,
+                storm_mask=np.array([[True]]),
+                depth=np.array([[0.5]], dtype=np.float64),
+                path=Path("snapshot.png"),
+                elapsed_minutes=15,
+            )
+
+        _, water_kwargs = axis.imshow.call_args_list[2]
+        self.assertNotIn("vmin", water_kwargs)
+        self.assertNotIn("vmax", water_kwargs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds an optional `output.snapshots.max_depth_meters` config value so simulation PNG snapshots can use a fixed water-depth color scale across frames.

## Changes

- Adds `SnapshotConfig.max_depth_meters` and parses it as an optional positive float.
- Threads the configured value through `write_snapshot(...)` into `render_snapshot(...)`.
- Uses fixed `vmin=0` and `vmax=max_depth_meters` for the water-depth layer when configured.
- Leaves the existing auto-scaling behavior unchanged when the value is omitted.
- Updates the example config and tests.

Closes #11

## Validation

- `git diff --check`
- `python -m compileall -q src tests`
- `PYTHONPATH=src python -m unittest tests.test_config`

Could not run `tests.test_engine` in this local bundled Python because `geopandas` is not installed in this environment.