### PR TITLE
[codex] Use water colormap for snapshots

### DIFF
--- a/src/nefas/engine.py
+++ b/src/nefas/engine.py
@@ -18,11 +18,18 @@ from .preprocessing import IntermediateOutputs
 from .simulation import RasterGrid, SimulationState
 
 matplotlib.use("Agg")
+from matplotlib.colors import LinearSegmentedColormap
 from matplotlib import pyplot as plt
 
 LOGGER = logging.getLogger(__name__)
 GRAVITY_METERS_PER_SECOND_SQUARED = 9.80665
 DRY_DEPTH_METERS = 0.001
+WATER_DEPTH_ALPHA = 0.82
+WATER_DEPTH_COLORMAP = LinearSegmentedColormap.from_list(
+    "nefas_water_depth",
+    ("#d8fbff", "#86d4ff", "#1f8be3", "#08306b"),
+)
+WATER_DEPTH_COLORMAP.set_bad((0, 0, 0, 0))
 
 
 @dataclass(frozen=True)
@@ -455,7 +462,7 @@ def render_snapshot(
     axis.imshow(np.where(storm_mask, 1.0, np.nan), cmap="Blues", alpha=0.22, vmin=0, vmax=1)
 
     depth_layer = np.ma.masked_where(depth <= 0, depth)
-    water = axis.imshow(depth_layer, cmap="turbo", alpha=0.75)
+    water = axis.imshow(depth_layer, cmap=WATER_DEPTH_COLORMAP, alpha=WATER_DEPTH_ALPHA)
     if np.nanmax(depth) > 0:
         colorbar = figure.colorbar(water, ax=axis, fraction=0.046, pad=0.04)
         colorbar.set_label("Water depth (m)")

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
 import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 
 from nefas.config import RainfallConfig, RainfallPoint
 from nefas.engine import (
+    WATER_DEPTH_ALPHA,
+    WATER_DEPTH_COLORMAP,
     add_rainfall_depth,
     apply_rainfall_forcing,
     rainfall_rate_m_per_second,
+    render_snapshot,
     timestep_duration_seconds,
     water_timestep,
 )
@@ -226,6 +231,29 @@ class EngineTests(unittest.TestCase):
         self.assertAlmostEqual(state.hydraulic.depth[0, 0], 0)
         self.assertAlmostEqual(state.hydraulic.depth[0, 1], 0.01)
         self.assertAlmostEqual(float(state.hydraulic.depth.sum()), 0.01)
+
+    def test_render_snapshot_uses_water_colormap(self) -> None:
+        grid = RasterGrid(
+            elevation=np.zeros((1, 1), dtype=np.float64),
+            dx=30,
+            dy=30,
+        )
+        figure = MagicMock()
+        axis = MagicMock()
+        axis.imshow.side_effect = [MagicMock(), MagicMock(), MagicMock()]
+
+        with patch("nefas.engine.plt.subplots", return_value=(figure, axis)):
+            render_snapshot(
+                grid,
+                storm_mask=np.array([[True]]),
+                depth=np.array([[0.5]], dtype=np.float64),
+                path=Path("snapshot.png"),
+                elapsed_minutes=15,
+            )
+
+        _, water_kwargs = axis.imshow.call_args_list[2]
+        self.assertIs(water_kwargs["cmap"], WATER_DEPTH_COLORMAP)
+        self.assertEqual(water_kwargs["alpha"], WATER_DEPTH_ALPHA)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Refactors simulation snapshot rendering to use a water-specific blue color ramp instead of the generic `turbo` palette.

## Changes

- Adds a NEFAS water-depth colormap with pale cyan shallow water and deeper blue high water.
- Keeps dry cells transparent via the existing masked depth layer plus transparent bad-color handling.
- Uses a consistent semi-transparent water overlay so the grayscale DEM remains readable beneath inundation.
- Adds renderer coverage to ensure snapshots use the water colormap and alpha.

Closes #13

## Validation

- `git diff --check`
- `python -m compileall -q src tests`

Could not run `tests.test_engine` in this local bundled Python because `geopandas` is not installed in this environment.