### PR TITLE
Add line profiler hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,16 @@ Prepare a model run from a YAML configuration:
 ```powershell
 python run_model.py examples/minimal_config.yaml
 ```
+
+## Line Profiling
+
+The main hydraulic timestep functions and snapshot renderer are decorated for
+line-level profiling with `line_profiler`. Enable profiling for a run with:
+
+```powershell
+$env:LINE_PROFILE = "1"
+python run_model.py examples/minimal_config.yaml
+```
+
+When the run exits, `line_profiler` prints per-line hit counts, total time, and
+time per hit for the profiled functions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "geopandas>=0.14",
+    "line-profiler>=4.1",
     "matplotlib>=3.9",
     "numpy>=1.26",
     "PyYAML>=6.0",

--- a/src/nefas/engine.py
+++ b/src/nefas/engine.py
@@ -15,6 +15,13 @@ from .config import RainfallConfig, SimulationConfig
 from .preprocessing import IntermediateOutputs
 from .simulation import RasterGrid, SimulationState
 
+try:
+    from line_profiler import profile
+except ImportError:
+    def profile(function):
+        return function
+
+
 matplotlib.use("Agg")
 from matplotlib.colors import LinearSegmentedColormap
 from matplotlib import pyplot as plt
@@ -275,6 +282,7 @@ def add_rainfall_depth(
     )
 
 
+@profile
 def water_timestep(state: SimulationState, dt_seconds: float) -> None:
     """Advance water depth with vectorized local-inertial face fluxes."""
     update_face_fluxes(state, dt_seconds)
@@ -282,6 +290,7 @@ def water_timestep(state: SimulationState, dt_seconds: float) -> None:
     update_depth_from_fluxes(state, dt_seconds)
 
 
+@profile
 def update_face_fluxes(state: SimulationState, dt_seconds: float) -> None:
     """Update interior face fluxes from water-surface slope and Manning friction."""
     grid = state.grid
@@ -393,6 +402,7 @@ def local_inertial_flux_update(
     return np.where(valid_faces & (face_depth >= DRY_DEPTH_METERS), flux, 0)
 
 
+@profile
 def limit_outgoing_fluxes(state: SimulationState, dt_seconds: float) -> None:
     """Scale outgoing face fluxes so no cell can lose more water than it stores."""
     depth = state.hydraulic.depth
@@ -419,6 +429,7 @@ def limit_outgoing_fluxes(state: SimulationState, dt_seconds: float) -> None:
     qy[-1, :] *= np.where(qy[-1, :] >= 0, scale[-1, :], 1)
 
 
+@profile
 def update_depth_from_fluxes(state: SimulationState, dt_seconds: float) -> None:
     """Update cell depths from vectorized face-flux divergence."""
     depth = state.hydraulic.depth
@@ -465,6 +476,7 @@ def write_snapshot(
     return snapshot
 
 
+@profile
 def render_snapshot(
     grid: RasterGrid,
     storm_mask: np.ndarray,


### PR DESCRIPTION
## Summary

Closes #15.

This adds optional `line_profiler` instrumentation to the main hydraulic timestep hot paths and snapshot rendering path:

- `water_timestep`
- `update_face_fluxes`
- `limit_outgoing_fluxes`
- `update_depth_from_fluxes`
- `render_snapshot`

The decorators use `line_profiler.profile` when available and fall back to a no-op decorator if the package is missing, so normal imports still work without profiling enabled. The package is also listed as a project dependency, and the README now documents enabling line profiling with `LINE_PROFILE=1`.

## Validation

- `git diff --check`
- `python -m compileall -q src tests`

Full engine tests were not run in this local runtime because this environment is missing geospatial dependencies such as `geopandas`.