### PR TITLE
Add configurable simulation runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ Prepare a model run from a YAML configuration:
 python run_model.py examples/minimal_config.yaml
 ```
 
+Configure model timing in YAML with `simulation_time`:
+
+```yaml
+simulation_time:
+  time_step_seconds: 5
+  max_time_step_seconds: 30
+  total_runtime_seconds: 172800
+```
+
+`total_runtime_seconds` controls the full simulation duration, so model runs can
+continue after the rainfall series ends and capture drainage.
+
 ## Line Profiling
 
 The main hydraulic timestep functions and snapshot renderer are decorated for

--- a/examples/minimal_config.yaml
+++ b/examples/minimal_config.yaml
@@ -18,9 +18,10 @@ rainfall:
     - time_minutes: 90
       rate_mm_per_hr: 5
 
-time_step:
-  seconds: 5
-  max_seconds: 30
+simulation_time:
+  time_step_seconds: 5
+  max_time_step_seconds: 30
+  total_runtime_seconds: 7200
 
 output:
   directory: outputs/example

--- a/src/nefas/config.py
+++ b/src/nefas/config.py
@@ -30,9 +30,23 @@ class RainfallConfig:
 
 
 @dataclass(frozen=True)
-class TimeStepConfig:
-    seconds: float
-    max_seconds: float | None = None
+class SimulationTimeConfig:
+    time_step_seconds: float
+    max_time_step_seconds: float | None = None
+    total_runtime_seconds: float | None = None
+
+    @property
+    def seconds(self) -> float:
+        """Compatibility alias for older callers using config.time_step.seconds."""
+        return self.time_step_seconds
+
+    @property
+    def max_seconds(self) -> float | None:
+        """Compatibility alias for older callers using config.time_step.max_seconds."""
+        return self.max_time_step_seconds
+
+
+TimeStepConfig = SimulationTimeConfig
 
 
 @dataclass(frozen=True)
@@ -62,9 +76,14 @@ class ProcessingConfig:
 class SimulationConfig:
     inputs: InputConfig
     rainfall: RainfallConfig
-    time_step: TimeStepConfig
+    simulation_time: SimulationTimeConfig
     output: OutputConfig
     processing: ProcessingConfig
+
+    @property
+    def time_step(self) -> SimulationTimeConfig:
+        """Compatibility alias for older callers using config.time_step."""
+        return self.simulation_time
 
 
 def load_config(path: Path) -> SimulationConfig:
@@ -83,7 +102,7 @@ def parse_config(raw: Any) -> SimulationConfig:
     root = _mapping(raw, "configuration")
     inputs = _mapping(root.get("inputs"), "inputs")
     rainfall = _mapping(root.get("rainfall"), "rainfall")
-    time_step = _mapping(root.get("time_step"), "time_step")
+    simulation_time = _simulation_time_config(root)
     output = _mapping(root.get("output"), "output")
     processing = root.get("processing") or {}
     processing = _mapping(processing, "processing")
@@ -95,10 +114,7 @@ def parse_config(raw: Any) -> SimulationConfig:
             storm_footprint=_path(inputs, "storm_footprint"),
         ),
         rainfall=RainfallConfig(series=_rainfall_series(rainfall)),
-        time_step=TimeStepConfig(
-            seconds=_float(time_step, "seconds", positive=True),
-            max_seconds=_optional_float(time_step, "max_seconds", positive=True),
-        ),
+        simulation_time=simulation_time,
         output=OutputConfig(
             directory=_path(output, "directory"),
             snapshots=_snapshot_config(output),
@@ -137,8 +153,40 @@ def _snapshot_config(section: dict[str, Any]) -> SnapshotConfig:
     )
     return SnapshotConfig(
         directory=Path(directory),
-        interval_minutes=_float({"interval_minutes": interval_minutes}, "interval_minutes", positive=True),
+        interval_minutes=_float(
+            {"interval_minutes": interval_minutes},
+            "interval_minutes",
+            positive=True,
+        ),
         max_depth_meters=_optional_float(snapshots, "max_depth_meters", positive=True),
+    )
+
+
+def _simulation_time_config(root: dict[str, Any]) -> SimulationTimeConfig:
+    if "simulation_time" in root:
+        simulation_time = _mapping(root.get("simulation_time"), "simulation_time")
+        return SimulationTimeConfig(
+            time_step_seconds=_float(
+                simulation_time,
+                "time_step_seconds",
+                positive=True,
+            ),
+            max_time_step_seconds=_optional_float(
+                simulation_time,
+                "max_time_step_seconds",
+                positive=True,
+            ),
+            total_runtime_seconds=_optional_float(
+                simulation_time,
+                "total_runtime_seconds",
+                positive=True,
+            ),
+        )
+
+    time_step = _mapping(root.get("time_step"), "time_step")
+    return SimulationTimeConfig(
+        time_step_seconds=_float(time_step, "seconds", positive=True),
+        max_time_step_seconds=_optional_float(time_step, "max_seconds", positive=True),
     )
 
 

--- a/src/nefas/engine.py
+++ b/src/nefas/engine.py
@@ -56,7 +56,7 @@ def run_simulation(
     storm_mask = storm_footprint_mask(
         config.inputs.storm_footprint, intermediates.clipped_dem
     )
-    duration_seconds = rainfall_duration_seconds(config.rainfall)
+    duration_seconds = simulation_duration_seconds(config)
     snapshot_interval_seconds = config.output.snapshots.interval_minutes * 60
 
     snapshot_directory = resolve_snapshot_directory(
@@ -83,7 +83,7 @@ def run_simulation(
                 current_time_seconds=state.hydraulic.time_seconds,
                 duration_seconds=duration_seconds,
                 next_snapshot_seconds=next_snapshot_seconds,
-                nominal_time_step_seconds=config.time_step.seconds,
+                nominal_time_step_seconds=effective_time_step_seconds(config),
             )
             run_timestep(
                 state,
@@ -151,6 +151,22 @@ def simulation_progress(duration_seconds: float) -> Iterator[object]:
 def rainfall_duration_seconds(rainfall: RainfallConfig) -> float:
     """Return the duration implied by the rainfall series."""
     return max(point.time_minutes for point in rainfall.series) * 60
+
+
+def simulation_duration_seconds(config: SimulationConfig) -> float:
+    """Return the configured simulation duration or the rainfall event duration."""
+    if config.simulation_time.total_runtime_seconds is not None:
+        return config.simulation_time.total_runtime_seconds
+    return rainfall_duration_seconds(config.rainfall)
+
+
+def effective_time_step_seconds(config: SimulationConfig) -> float:
+    """Return the timestep duration after applying the optional maximum cap."""
+    time_step_seconds = config.simulation_time.time_step_seconds
+    max_time_step_seconds = config.simulation_time.max_time_step_seconds
+    if max_time_step_seconds is None:
+        return time_step_seconds
+    return min(time_step_seconds, max_time_step_seconds)
 
 
 def timestep_duration_seconds(
@@ -265,7 +281,7 @@ def rainfall_rate_m_per_second(
             )
             return rate_mm_per_hr / 1000 / 3600
 
-    return points[-1].rate_mm_per_hr / 1000 / 3600
+    return 0
 
 
 def add_rainfall_depth(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,7 +21,11 @@ class ConfigParsingTests(unittest.TestCase):
                         {"time_minutes": 15, "rate_mm_per_hr": 25},
                     ]
                 },
-                "time_step": {"seconds": 5},
+                "simulation_time": {
+                    "time_step_seconds": 5,
+                    "max_time_step_seconds": 30,
+                    "total_runtime_seconds": 7200,
+                },
                 "output": {
                     "directory": "outputs/example",
                     "snapshots": {
@@ -43,7 +47,11 @@ class ConfigParsingTests(unittest.TestCase):
 
         self.assertEqual(config.inputs.dem, Path("data/dem.tif"))
         self.assertEqual(config.rainfall.series[1].rate_mm_per_hr, 25)
+        self.assertEqual(config.simulation_time.time_step_seconds, 5)
+        self.assertEqual(config.simulation_time.max_time_step_seconds, 30)
+        self.assertEqual(config.simulation_time.total_runtime_seconds, 7200)
         self.assertEqual(config.time_step.seconds, 5)
+        self.assertEqual(config.time_step.max_seconds, 30)
         self.assertEqual(config.output.directory, Path("outputs/example"))
         self.assertEqual(config.output.snapshots.directory, Path("frames"))
         self.assertEqual(config.output.snapshots.interval_minutes, 10)
@@ -66,7 +74,7 @@ class ConfigParsingTests(unittest.TestCase):
                         {"time_minutes": 0, "rate_mm_per_hr": 0},
                     ]
                 },
-                "time_step": {"seconds": 5},
+                "simulation_time": {"time_step_seconds": 5},
                 "output": {"directory": "outputs/example"},
             }
         )
@@ -89,10 +97,32 @@ class ConfigParsingTests(unittest.TestCase):
                         "storm_footprint": "data/storm.gpkg",
                     },
                     "rainfall": {"series": []},
-                    "time_step": {"seconds": 5},
+                    "simulation_time": {"time_step_seconds": 5},
                     "output": {"directory": "outputs/example"},
                 }
             )
+
+    def test_accepts_legacy_time_step_configuration(self) -> None:
+        config = parse_config(
+            {
+                "inputs": {
+                    "dem": "data/dem.tif",
+                    "area_of_interest": "data/aoi.gpkg",
+                    "storm_footprint": "data/storm.gpkg",
+                },
+                "rainfall": {
+                    "series": [
+                        {"time_minutes": 0, "rate_mm_per_hr": 0},
+                    ]
+                },
+                "time_step": {"seconds": 10, "max_seconds": 60},
+                "output": {"directory": "outputs/example"},
+            }
+        )
+
+        self.assertEqual(config.simulation_time.time_step_seconds, 10)
+        self.assertEqual(config.simulation_time.max_time_step_seconds, 60)
+        self.assertIsNone(config.simulation_time.total_runtime_seconds)
 
 
 if __name__ == "__main__":

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -6,18 +6,60 @@ from unittest.mock import MagicMock, patch
 
 import numpy as np
 
-from nefas.config import RainfallConfig, RainfallPoint
+from nefas.config import (
+    AreaOfInterestProcessingConfig,
+    InputConfig,
+    OutputConfig,
+    ProcessingConfig,
+    RainfallConfig,
+    RainfallPoint,
+    SimulationConfig,
+    SimulationTimeConfig,
+    SnapshotConfig,
+)
 from nefas.engine import (
     WATER_DEPTH_ALPHA,
     WATER_DEPTH_COLORMAP,
     add_rainfall_depth,
     apply_rainfall_forcing,
+    effective_time_step_seconds,
     rainfall_rate_m_per_second,
     render_snapshot,
+    simulation_duration_seconds,
     timestep_duration_seconds,
     water_timestep,
 )
 from nefas.simulation import RasterGrid, SimulationState
+
+
+def make_simulation_config(
+    *,
+    simulation_time: SimulationTimeConfig,
+) -> SimulationConfig:
+    return SimulationConfig(
+        inputs=InputConfig(
+            dem=Path("data/dem.tif"),
+            area_of_interest=Path("data/aoi.gpkg"),
+            storm_footprint=Path("data/storm.gpkg"),
+        ),
+        rainfall=RainfallConfig(
+            series=(
+                RainfallPoint(time_minutes=0, rate_mm_per_hr=0),
+                RainfallPoint(time_minutes=60, rate_mm_per_hr=60),
+            )
+        ),
+        simulation_time=simulation_time,
+        output=OutputConfig(
+            directory=Path("outputs/example"),
+            snapshots=SnapshotConfig(
+                directory=Path("snapshots"),
+                interval_minutes=15,
+            ),
+        ),
+        processing=ProcessingConfig(
+            area_of_interest=AreaOfInterestProcessingConfig(filters={})
+        ),
+    )
 
 
 class EngineTests(unittest.TestCase):
@@ -53,6 +95,43 @@ class EngineTests(unittest.TestCase):
             rainfall_rate_m_per_second(rainfall, elapsed_seconds=1800),
             0.03 / 3600,
         )
+
+    def test_rainfall_rate_is_zero_after_final_rainfall_point(self) -> None:
+        rainfall = RainfallConfig(
+            series=(
+                RainfallPoint(time_minutes=0, rate_mm_per_hr=0),
+                RainfallPoint(time_minutes=60, rate_mm_per_hr=60),
+            )
+        )
+
+        self.assertEqual(rainfall_rate_m_per_second(rainfall, elapsed_seconds=3601), 0)
+
+    def test_simulation_duration_uses_configured_runtime_when_present(self) -> None:
+        config = make_simulation_config(
+            simulation_time=SimulationTimeConfig(
+                time_step_seconds=5,
+                total_runtime_seconds=7200,
+            )
+        )
+
+        self.assertEqual(simulation_duration_seconds(config), 7200)
+
+    def test_simulation_duration_falls_back_to_rainfall_duration(self) -> None:
+        config = make_simulation_config(
+            simulation_time=SimulationTimeConfig(time_step_seconds=5)
+        )
+
+        self.assertEqual(simulation_duration_seconds(config), 3600)
+
+    def test_effective_time_step_applies_maximum_cap(self) -> None:
+        config = make_simulation_config(
+            simulation_time=SimulationTimeConfig(
+                time_step_seconds=60,
+                max_time_step_seconds=30,
+            )
+        )
+
+        self.assertEqual(effective_time_step_seconds(config), 30)
 
     def test_apply_rainfall_forcing_adds_depth_only_to_valid_storm_cells(self) -> None:
         grid = RasterGrid(


### PR DESCRIPTION
## Summary

Closes #17.

This adds a clearer `simulation_time` YAML block for model timing:

```yaml
simulation_time:
  time_step_seconds: 5
  max_time_step_seconds: 30
  total_runtime_seconds: 172800
```

The engine now uses `total_runtime_seconds` when provided, so runs can continue after the rainfall series ends and capture post-storm drainage. The older `time_step.seconds` / `time_step.max_seconds` config shape still parses for compatibility, and `config.time_step` remains available as an alias for older callers.

I chose `time_step_seconds` instead of `min_time_step_seconds` because the current engine still uses a fixed timestep rather than adaptive stepping. `max_time_step_seconds` is treated as a cap on the configured step.

## Validation

- `git diff --check`
- `python -m compileall -q src tests`
- `PYTHONPATH=src python -m unittest tests.test_config`

`PYTHONPATH=src python -m unittest discover -s tests` was attempted, but this local runtime is missing geospatial dependencies (`geopandas`, `rasterio`), so engine/preprocessing/simulation test modules cannot import here.