### PR TITLE
Fuse face flux calculations in Numba

### DIFF
--- a/src/nefas/engine.py
+++ b/src/nefas/engine.py
@@ -12,7 +12,7 @@ import numpy as np
 import rasterio
 from rasterio.features import rasterize
 from line_profiler import profile
-from numba import boolean, float64, vectorize
+from numba import boolean, float64, njit, prange, vectorize
 
 from .config import RainfallConfig, SimulationConfig
 from .preprocessing import IntermediateOutputs
@@ -304,83 +304,218 @@ def update_face_fluxes(state: SimulationState, dt_seconds: float) -> None:
     surface = state.surface
     eta = hydraulic.water_surface(grid)
 
-    qx_old = hydraulic.qx[:, 1:-1]
-    # Face depth uses the higher adjacent terrain cell as the sill elevation.
-    h_face_x = np.maximum(
-        0,
-        np.maximum(eta[:, :-1], eta[:, 1:])
-        - np.maximum(grid.elevation[:, :-1], grid.elevation[:, 1:]),
+    update_interior_x_fluxes_numba(
+        hydraulic.qx,
+        eta,
+        grid.elevation,
+        surface.manning_n,
+        grid.valid_cells,
+        grid.dx,
+        dt_seconds,
     )
-    valid_x = grid.valid_cells[:, :-1] & grid.valid_cells[:, 1:]
-    slope_x = (eta[:, 1:] - eta[:, :-1]) / grid.dx
-    n_face_x = 0.5 * (surface.manning_n[:, :-1] + surface.manning_n[:, 1:])
-    hydraulic.qx[:, 1:-1] = local_inertial_flux_update_numba(
-        qx_old,
-        h_face_x,
-        slope_x,
-        n_face_x,
-        valid_x,
+    update_x_boundary_fluxes_numba(
+        hydraulic.qx,
+        hydraulic.depth,
+        eta,
+        grid.elevation,
+        surface.manning_n,
+        grid.valid_cells,
+        grid.dx,
         dt_seconds,
     )
 
-    # Open boundaries are dry outside cells; outward flux leaves the domain.
-    left_boundary_flux = local_inertial_flux_update_numba(
-        hydraulic.qx[:, 0],
-        hydraulic.depth[:, 0],
-        (eta[:, 0] - grid.elevation[:, 0]) / grid.dx,
-        surface.manning_n[:, 0],
-        grid.valid_cells[:, 0],
+    update_interior_y_fluxes_numba(
+        hydraulic.qy,
+        eta,
+        grid.elevation,
+        surface.manning_n,
+        grid.valid_cells,
+        grid.dy,
         dt_seconds,
     )
-    hydraulic.qx[:, 0] = np.minimum(left_boundary_flux, 0)
-    right_boundary_flux = local_inertial_flux_update_numba(
-        hydraulic.qx[:, -1],
-        hydraulic.depth[:, -1],
-        (grid.elevation[:, -1] - eta[:, -1]) / grid.dx,
-        surface.manning_n[:, -1],
-        grid.valid_cells[:, -1],
-        dt_seconds,
-    )
-    hydraulic.qx[:, -1] = np.maximum(right_boundary_flux, 0)
-
-    qy_old = hydraulic.qy[1:-1, :]
-    # Face depth uses the higher adjacent terrain cell as the sill elevation.
-    h_face_y = np.maximum(
-        0,
-        np.maximum(eta[:-1, :], eta[1:, :])
-        - np.maximum(grid.elevation[:-1, :], grid.elevation[1:, :]),
-    )
-    valid_y = grid.valid_cells[:-1, :] & grid.valid_cells[1:, :]
-    slope_y = (eta[1:, :] - eta[:-1, :]) / grid.dy
-    n_face_y = 0.5 * (surface.manning_n[:-1, :] + surface.manning_n[1:, :])
-    hydraulic.qy[1:-1, :] = local_inertial_flux_update_numba(
-        qy_old,
-        h_face_y,
-        slope_y,
-        n_face_y,
-        valid_y,
+    update_y_boundary_fluxes_numba(
+        hydraulic.qy,
+        hydraulic.depth,
+        eta,
+        grid.elevation,
+        surface.manning_n,
+        grid.valid_cells,
+        grid.dy,
         dt_seconds,
     )
 
-    # Open boundaries are dry outside cells; outward flux leaves the domain.
-    top_boundary_flux = local_inertial_flux_update_numba(
-        hydraulic.qy[0, :],
-        hydraulic.depth[0, :],
-        (eta[0, :] - grid.elevation[0, :]) / grid.dy,
-        surface.manning_n[0, :],
-        grid.valid_cells[0, :],
-        dt_seconds,
+
+@njit(
+    float64(float64, float64, float64, float64, boolean, float64),
+    cache=True,
+    inline="always",
+)
+def local_inertial_flux_update_value(
+    old_flux: float,
+    face_depth: float,
+    slope: float,
+    manning_n: float,
+    valid_face: bool,
+    dt_seconds: float,
+) -> float:
+    """Return one local-inertial flux update value."""
+    if not valid_face or face_depth < DRY_DEPTH_METERS:
+        return 0.0
+
+    depth_safe = max(face_depth, DRY_DEPTH_METERS)
+    denominator = (
+        1.0
+        + GRAVITY_METERS_PER_SECOND_SQUARED
+        * dt_seconds
+        * manning_n**2
+        * abs(old_flux)
+        / depth_safe ** (7.0 / 3.0)
     )
-    hydraulic.qy[0, :] = np.minimum(top_boundary_flux, 0)
-    bottom_boundary_flux = local_inertial_flux_update_numba(
-        hydraulic.qy[-1, :],
-        hydraulic.depth[-1, :],
-        (grid.elevation[-1, :] - eta[-1, :]) / grid.dy,
-        surface.manning_n[-1, :],
-        grid.valid_cells[-1, :],
-        dt_seconds,
-    )
-    hydraulic.qy[-1, :] = np.maximum(bottom_boundary_flux, 0)
+    return (
+        old_flux - GRAVITY_METERS_PER_SECOND_SQUARED * face_depth * dt_seconds * slope
+    ) / denominator
+
+
+@njit(cache=True, parallel=True)
+def update_interior_x_fluxes_numba(
+    qx: np.ndarray,
+    eta: np.ndarray,
+    elevation: np.ndarray,
+    manning_n: np.ndarray,
+    valid_cells: np.ndarray,
+    dx: float,
+    dt_seconds: float,
+) -> None:
+    """Update east-west interior face fluxes in one compiled pass."""
+    rows, cols = eta.shape
+    for row in prange(rows):
+        for col in range(cols - 1):
+            face_depth = max(
+                0.0,
+                max(eta[row, col], eta[row, col + 1])
+                - max(elevation[row, col], elevation[row, col + 1]),
+            )
+            slope = (eta[row, col + 1] - eta[row, col]) / dx
+            face_manning_n = 0.5 * (
+                manning_n[row, col] + manning_n[row, col + 1]
+            )
+            valid_face = valid_cells[row, col] and valid_cells[row, col + 1]
+            qx[row, col + 1] = local_inertial_flux_update_value(
+                qx[row, col + 1],
+                face_depth,
+                slope,
+                face_manning_n,
+                valid_face,
+                dt_seconds,
+            )
+
+
+@njit(cache=True, parallel=True)
+def update_interior_y_fluxes_numba(
+    qy: np.ndarray,
+    eta: np.ndarray,
+    elevation: np.ndarray,
+    manning_n: np.ndarray,
+    valid_cells: np.ndarray,
+    dy: float,
+    dt_seconds: float,
+) -> None:
+    """Update north-south interior face fluxes in one compiled pass."""
+    rows, cols = eta.shape
+    for row in prange(rows - 1):
+        for col in range(cols):
+            face_depth = max(
+                0.0,
+                max(eta[row, col], eta[row + 1, col])
+                - max(elevation[row, col], elevation[row + 1, col]),
+            )
+            slope = (eta[row + 1, col] - eta[row, col]) / dy
+            face_manning_n = 0.5 * (
+                manning_n[row, col] + manning_n[row + 1, col]
+            )
+            valid_face = valid_cells[row, col] and valid_cells[row + 1, col]
+            qy[row + 1, col] = local_inertial_flux_update_value(
+                qy[row + 1, col],
+                face_depth,
+                slope,
+                face_manning_n,
+                valid_face,
+                dt_seconds,
+            )
+
+
+@njit(cache=True, parallel=True)
+def update_x_boundary_fluxes_numba(
+    qx: np.ndarray,
+    depth: np.ndarray,
+    eta: np.ndarray,
+    elevation: np.ndarray,
+    manning_n: np.ndarray,
+    valid_cells: np.ndarray,
+    dx: float,
+    dt_seconds: float,
+) -> None:
+    """Update open east-west boundary fluxes in one compiled pass."""
+    rows = eta.shape[0]
+    right_col = eta.shape[1] - 1
+    right_face = qx.shape[1] - 1
+    for row in prange(rows):
+        left_flux = local_inertial_flux_update_value(
+            qx[row, 0],
+            depth[row, 0],
+            (eta[row, 0] - elevation[row, 0]) / dx,
+            manning_n[row, 0],
+            valid_cells[row, 0],
+            dt_seconds,
+        )
+        qx[row, 0] = min(left_flux, 0.0)
+
+        right_flux = local_inertial_flux_update_value(
+            qx[row, right_face],
+            depth[row, right_col],
+            (elevation[row, right_col] - eta[row, right_col]) / dx,
+            manning_n[row, right_col],
+            valid_cells[row, right_col],
+            dt_seconds,
+        )
+        qx[row, right_face] = max(right_flux, 0.0)
+
+
+@njit(cache=True, parallel=True)
+def update_y_boundary_fluxes_numba(
+    qy: np.ndarray,
+    depth: np.ndarray,
+    eta: np.ndarray,
+    elevation: np.ndarray,
+    manning_n: np.ndarray,
+    valid_cells: np.ndarray,
+    dy: float,
+    dt_seconds: float,
+) -> None:
+    """Update open north-south boundary fluxes in one compiled pass."""
+    cols = eta.shape[1]
+    bottom_row = eta.shape[0] - 1
+    bottom_face = qy.shape[0] - 1
+    for col in prange(cols):
+        top_flux = local_inertial_flux_update_value(
+            qy[0, col],
+            depth[0, col],
+            (eta[0, col] - elevation[0, col]) / dy,
+            manning_n[0, col],
+            valid_cells[0, col],
+            dt_seconds,
+        )
+        qy[0, col] = min(top_flux, 0.0)
+
+        bottom_flux = local_inertial_flux_update_value(
+            qy[bottom_face, col],
+            depth[bottom_row, col],
+            (elevation[bottom_row, col] - eta[bottom_row, col]) / dy,
+            manning_n[bottom_row, col],
+            valid_cells[bottom_row, col],
+            dt_seconds,
+        )
+        qy[bottom_face, col] = max(bottom_flux, 0.0)
 
 
 @vectorize(

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -29,6 +29,8 @@ from nefas.engine import (
     render_snapshot,
     simulation_duration_seconds,
     timestep_duration_seconds,
+    update_interior_x_fluxes_numba,
+    update_interior_y_fluxes_numba,
     water_timestep,
 )
 from nefas.simulation import RasterGrid, SimulationState
@@ -183,6 +185,144 @@ class EngineTests(unittest.TestCase):
         )
 
         np.testing.assert_allclose(actual, expected)
+
+    def test_fused_x_flux_kernel_matches_numpy_reference(self) -> None:
+        elevation = np.array(
+            [
+                [0.0, 0.1, 0.0],
+                [0.2, 0.0, 0.3],
+            ],
+            dtype=np.float64,
+        )
+        depth = np.array(
+            [
+                [0.3, 0.0, 0.5],
+                [0.0, 0.4, 0.2],
+            ],
+            dtype=np.float64,
+        )
+        eta = elevation + depth
+        manning_n = np.array(
+            [
+                [0.04, 0.08, 0.12],
+                [0.05, 0.07, 0.09],
+            ],
+            dtype=np.float64,
+        )
+        valid_cells = np.array(
+            [
+                [True, True, False],
+                [True, True, True],
+            ]
+        )
+        qx = np.array(
+            [
+                [0.0, 0.1, -0.2, 0.0],
+                [0.0, 0.3, -0.4, 0.0],
+            ],
+            dtype=np.float64,
+        )
+
+        h_face_x = np.maximum(
+            0,
+            np.maximum(eta[:, :-1], eta[:, 1:])
+            - np.maximum(elevation[:, :-1], elevation[:, 1:]),
+        )
+        slope_x = (eta[:, 1:] - eta[:, :-1]) / 30.0
+        n_face_x = 0.5 * (manning_n[:, :-1] + manning_n[:, 1:])
+        valid_x = valid_cells[:, :-1] & valid_cells[:, 1:]
+        expected = local_inertial_flux_update(
+            old_flux=qx[:, 1:-1],
+            face_depth=h_face_x,
+            slope=slope_x,
+            manning_n=n_face_x,
+            valid_faces=valid_x,
+            dt_seconds=5.0,
+        )
+
+        update_interior_x_fluxes_numba(
+            qx,
+            eta,
+            elevation,
+            manning_n,
+            valid_cells,
+            30.0,
+            5.0,
+        )
+
+        np.testing.assert_allclose(qx[:, 1:-1], expected)
+
+    def test_fused_y_flux_kernel_matches_numpy_reference(self) -> None:
+        elevation = np.array(
+            [
+                [0.0, 0.1],
+                [0.2, 0.0],
+                [0.1, 0.3],
+            ],
+            dtype=np.float64,
+        )
+        depth = np.array(
+            [
+                [0.3, 0.0],
+                [0.0, 0.4],
+                [0.2, 0.1],
+            ],
+            dtype=np.float64,
+        )
+        eta = elevation + depth
+        manning_n = np.array(
+            [
+                [0.04, 0.08],
+                [0.05, 0.07],
+                [0.06, 0.09],
+            ],
+            dtype=np.float64,
+        )
+        valid_cells = np.array(
+            [
+                [True, True],
+                [True, False],
+                [True, True],
+            ]
+        )
+        qy = np.array(
+            [
+                [0.0, 0.0],
+                [0.1, -0.2],
+                [0.3, -0.4],
+                [0.0, 0.0],
+            ],
+            dtype=np.float64,
+        )
+
+        h_face_y = np.maximum(
+            0,
+            np.maximum(eta[:-1, :], eta[1:, :])
+            - np.maximum(elevation[:-1, :], elevation[1:, :]),
+        )
+        slope_y = (eta[1:, :] - eta[:-1, :]) / 30.0
+        n_face_y = 0.5 * (manning_n[:-1, :] + manning_n[1:, :])
+        valid_y = valid_cells[:-1, :] & valid_cells[1:, :]
+        expected = local_inertial_flux_update(
+            old_flux=qy[1:-1, :],
+            face_depth=h_face_y,
+            slope=slope_y,
+            manning_n=n_face_y,
+            valid_faces=valid_y,
+            dt_seconds=5.0,
+        )
+
+        update_interior_y_fluxes_numba(
+            qy,
+            eta,
+            elevation,
+            manning_n,
+            valid_cells,
+            30.0,
+            5.0,
+        )
+
+        np.testing.assert_allclose(qy[1:-1, :], expected)
 
     def test_apply_rainfall_forcing_adds_depth_only_to_valid_storm_cells(self) -> None:
         grid = RasterGrid(


### PR DESCRIPTION
## Summary

Closes #23.

This moves the remaining per-face setup work inside `update_face_fluxes` into compiled Numba kernels. The previous Numba pass compiled the final local-inertial flux equation, but `update_face_fluxes` still used NumPy to allocate and fill `h_face_*`, `slope_*`, `n_face_*`, and `valid_*` arrays. This PR fuses those calculations into the compiled loops.

## Changes

- Add fused Numba kernels for interior east-west and north-south face flux updates.
- Add fused Numba kernels for open-boundary east-west and north-south flux updates.
- Keep the existing NumPy `local_inertial_flux_update` reference implementation.
- Keep the vectorized Numba flux helper available, but route `update_face_fluxes` through the fused kernels.
- Add tests comparing fused x/y interior kernels to the NumPy reference calculation.

## Validation

- `git diff --check`
- `python -m compileall -q src tests`
- `PYTHONPATH=src python -m unittest tests.test_config`

`PYTHONPATH=src python -m unittest tests.test_engine` was attempted, but this bundled local runtime is missing dependencies such as `tqdm` and `numba`, so the engine test module cannot import here.