### PR TITLE
Compile outgoing flux limiter with Numba

### DIFF
--- a/src/nefas/engine.py
+++ b/src/nefas/engine.py
@@ -578,6 +578,72 @@ def local_inertial_flux_update(
 
 @profile
 def limit_outgoing_fluxes(state: SimulationState, dt_seconds: float) -> None:
+    """Scale outgoing face fluxes with a compiled limiter."""
+    limit_outgoing_fluxes_numba(
+        state.hydraulic.depth,
+        state.hydraulic.qx,
+        state.hydraulic.qy,
+        state.grid.valid_cells,
+        state.grid.dx,
+        state.grid.dy,
+        dt_seconds,
+    )
+
+
+@njit(cache=True, parallel=True)
+def limit_outgoing_fluxes_numba(
+    depth: np.ndarray,
+    qx: np.ndarray,
+    qy: np.ndarray,
+    valid_cells: np.ndarray,
+    dx: float,
+    dy: float,
+    dt_seconds: float,
+) -> None:
+    """Scale outgoing face fluxes in compiled loops."""
+    rows, cols = depth.shape
+    scale = np.ones(depth.shape, dtype=np.float64)
+
+    for row in prange(rows):
+        for col in range(cols):
+            outgoing_depth = dt_seconds * (
+                max(qx[row, col + 1], 0.0) / dx
+                + max(-qx[row, col], 0.0) / dx
+                + max(qy[row + 1, col], 0.0) / dy
+                + max(-qy[row, col], 0.0) / dy
+            )
+            if valid_cells[row, col] and outgoing_depth > depth[row, col]:
+                if outgoing_depth > 0.0:
+                    scale[row, col] = depth[row, col] / outgoing_depth
+
+    for row in prange(rows):
+        for col in range(1, cols):
+            if qx[row, col] >= 0.0:
+                qx[row, col] *= scale[row, col - 1]
+            else:
+                qx[row, col] *= scale[row, col]
+
+    for row in prange(rows):
+        if qx[row, 0] < 0.0:
+            qx[row, 0] *= scale[row, 0]
+        if qx[row, cols] >= 0.0:
+            qx[row, cols] *= scale[row, cols - 1]
+
+    for row in prange(1, rows):
+        for col in range(cols):
+            if qy[row, col] >= 0.0:
+                qy[row, col] *= scale[row - 1, col]
+            else:
+                qy[row, col] *= scale[row, col]
+
+    for col in prange(cols):
+        if qy[0, col] < 0.0:
+            qy[0, col] *= scale[0, col]
+        if qy[rows, col] >= 0.0:
+            qy[rows, col] *= scale[rows - 1, col]
+
+
+def limit_outgoing_fluxes_numpy(state: SimulationState, dt_seconds: float) -> None:
     """Scale outgoing face fluxes so no cell can lose more water than it stores."""
     depth = state.hydraulic.depth
     qx = state.hydraulic.qx

--- a/src/nefas/engine.py
+++ b/src/nefas/engine.py
@@ -292,7 +292,15 @@ def add_rainfall_depth(
 def water_timestep(state: SimulationState, dt_seconds: float) -> None:
     """Advance water depth with vectorized local-inertial face fluxes."""
     update_face_fluxes(state, dt_seconds)
-    limit_outgoing_fluxes(state, dt_seconds)
+    limit_outgoing_fluxes(
+        state.hydraulic.depth,
+        state.hydraulic.qx,
+        state.hydraulic.qy,
+        state.grid.valid_cells,
+        state.grid.dx,
+        state.grid.dy,
+        dt_seconds,
+    )
     update_depth_from_fluxes(state, dt_seconds)
 
 
@@ -576,22 +584,8 @@ def local_inertial_flux_update(
     return np.where(valid_faces & (face_depth >= DRY_DEPTH_METERS), flux, 0)
 
 
-@profile
-def limit_outgoing_fluxes(state: SimulationState, dt_seconds: float) -> None:
-    """Scale outgoing face fluxes with a compiled limiter."""
-    limit_outgoing_fluxes_numba(
-        state.hydraulic.depth,
-        state.hydraulic.qx,
-        state.hydraulic.qy,
-        state.grid.valid_cells,
-        state.grid.dx,
-        state.grid.dy,
-        dt_seconds,
-    )
-
-
 @njit(cache=True, parallel=True)
-def limit_outgoing_fluxes_numba(
+def limit_outgoing_fluxes(
     depth: np.ndarray,
     qx: np.ndarray,
     qy: np.ndarray,
@@ -641,32 +635,6 @@ def limit_outgoing_fluxes_numba(
             qy[0, col] *= scale[0, col]
         if qy[rows, col] >= 0.0:
             qy[rows, col] *= scale[rows - 1, col]
-
-
-def limit_outgoing_fluxes_numpy(state: SimulationState, dt_seconds: float) -> None:
-    """Scale outgoing face fluxes so no cell can lose more water than it stores."""
-    depth = state.hydraulic.depth
-    qx = state.hydraulic.qx
-    qy = state.hydraulic.qy
-    valid_cells = state.grid.valid_cells
-
-    outgoing_depth = dt_seconds * (
-        np.maximum(qx[:, 1:], 0) / state.grid.dx
-        + np.maximum(-qx[:, :-1], 0) / state.grid.dx
-        + np.maximum(qy[1:, :], 0) / state.grid.dy
-        + np.maximum(-qy[:-1, :], 0) / state.grid.dy
-    )
-    scale = np.ones_like(depth)
-    needs_limit = valid_cells & (outgoing_depth > depth) & (outgoing_depth > 0)
-    scale[needs_limit] = depth[needs_limit] / outgoing_depth[needs_limit]
-
-    qx[:, 1:-1] *= np.where(qx[:, 1:-1] >= 0, scale[:, :-1], scale[:, 1:])
-    qx[:, 0] *= np.where(qx[:, 0] >= 0, 1, scale[:, 0])
-    qx[:, -1] *= np.where(qx[:, -1] >= 0, scale[:, -1], 1)
-
-    qy[1:-1, :] *= np.where(qy[1:-1, :] >= 0, scale[:-1, :], scale[1:, :])
-    qy[0, :] *= np.where(qy[0, :] >= 0, 1, scale[0, :])
-    qy[-1, :] *= np.where(qy[-1, :] >= 0, scale[-1, :], 1)
 
 
 @profile

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -23,8 +23,7 @@ from nefas.engine import (
     add_rainfall_depth,
     apply_rainfall_forcing,
     effective_time_step_seconds,
-    limit_outgoing_fluxes_numba,
-    limit_outgoing_fluxes_numpy,
+    limit_outgoing_fluxes,
     local_inertial_flux_update,
     local_inertial_flux_update_numba,
     rainfall_rate_m_per_second,
@@ -326,69 +325,34 @@ class EngineTests(unittest.TestCase):
 
         np.testing.assert_allclose(qy[1:-1, :], expected)
 
-    def test_numba_outgoing_flux_limiter_matches_numpy_reference(self) -> None:
-        grid = RasterGrid(
-            elevation=np.zeros((2, 2), dtype=np.float64),
-            dx=10,
-            dy=20,
-        )
-        depth = np.array(
-            [
-                [0.10, 0.20],
-                [0.15, 0.05],
-            ],
-            dtype=np.float64,
-        )
-        qx = np.array(
-            [
-                [-0.5, 0.4, 0.6],
-                [-0.1, -0.3, 0.2],
-            ],
-            dtype=np.float64,
-        )
+    def test_outgoing_flux_limiter_scales_boundary_and_interior_outflows(self) -> None:
+        depth = np.array([[0.10, 0.20]], dtype=np.float64)
+        qx = np.array([[-0.5, 0.4, 0.6]], dtype=np.float64)
         qy = np.array(
             [
                 [-0.2, -0.1],
-                [0.5, -0.4],
                 [0.3, 0.2],
             ],
             dtype=np.float64,
         )
-        expected_state = SimulationState.dry(
-            grid,
-            manning_n=0.08,
-            runoff_coefficient=1.0,
-        )
-        actual_state = SimulationState.dry(
-            grid,
-            manning_n=0.08,
-            runoff_coefficient=1.0,
-        )
-        expected_state.hydraulic.depth[:, :] = depth
-        expected_state.hydraulic.qx[:, :] = qx
-        expected_state.hydraulic.qy[:, :] = qy
-        actual_state.hydraulic.depth[:, :] = depth
-        actual_state.hydraulic.qx[:, :] = qx
-        actual_state.hydraulic.qy[:, :] = qy
 
-        limit_outgoing_fluxes_numpy(expected_state, dt_seconds=5.0)
-        limit_outgoing_fluxes_numba(
-            actual_state.hydraulic.depth,
-            actual_state.hydraulic.qx,
-            actual_state.hydraulic.qy,
-            actual_state.grid.valid_cells,
-            actual_state.grid.dx,
-            actual_state.grid.dy,
+        limit_outgoing_fluxes(
+            depth,
+            qx,
+            qy,
+            np.array([[True, True]]),
+            10.0,
+            20.0,
             5.0,
         )
 
         np.testing.assert_allclose(
-            actual_state.hydraulic.qx,
-            expected_state.hydraulic.qx,
+            qx,
+            np.array([[-0.08695652, 0.06956522, 0.32]]),
         )
         np.testing.assert_allclose(
-            actual_state.hydraulic.qy,
-            expected_state.hydraulic.qy,
+            qy,
+            np.array([[-0.03478261, -0.05333333], [0.05217391, 0.10666667]]),
         )
 
     def test_apply_rainfall_forcing_adds_depth_only_to_valid_storm_cells(self) -> None:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -23,6 +23,8 @@ from nefas.engine import (
     add_rainfall_depth,
     apply_rainfall_forcing,
     effective_time_step_seconds,
+    limit_outgoing_fluxes_numba,
+    limit_outgoing_fluxes_numpy,
     local_inertial_flux_update,
     local_inertial_flux_update_numba,
     rainfall_rate_m_per_second,
@@ -323,6 +325,71 @@ class EngineTests(unittest.TestCase):
         )
 
         np.testing.assert_allclose(qy[1:-1, :], expected)
+
+    def test_numba_outgoing_flux_limiter_matches_numpy_reference(self) -> None:
+        grid = RasterGrid(
+            elevation=np.zeros((2, 2), dtype=np.float64),
+            dx=10,
+            dy=20,
+        )
+        depth = np.array(
+            [
+                [0.10, 0.20],
+                [0.15, 0.05],
+            ],
+            dtype=np.float64,
+        )
+        qx = np.array(
+            [
+                [-0.5, 0.4, 0.6],
+                [-0.1, -0.3, 0.2],
+            ],
+            dtype=np.float64,
+        )
+        qy = np.array(
+            [
+                [-0.2, -0.1],
+                [0.5, -0.4],
+                [0.3, 0.2],
+            ],
+            dtype=np.float64,
+        )
+        expected_state = SimulationState.dry(
+            grid,
+            manning_n=0.08,
+            runoff_coefficient=1.0,
+        )
+        actual_state = SimulationState.dry(
+            grid,
+            manning_n=0.08,
+            runoff_coefficient=1.0,
+        )
+        expected_state.hydraulic.depth[:, :] = depth
+        expected_state.hydraulic.qx[:, :] = qx
+        expected_state.hydraulic.qy[:, :] = qy
+        actual_state.hydraulic.depth[:, :] = depth
+        actual_state.hydraulic.qx[:, :] = qx
+        actual_state.hydraulic.qy[:, :] = qy
+
+        limit_outgoing_fluxes_numpy(expected_state, dt_seconds=5.0)
+        limit_outgoing_fluxes_numba(
+            actual_state.hydraulic.depth,
+            actual_state.hydraulic.qx,
+            actual_state.hydraulic.qy,
+            actual_state.grid.valid_cells,
+            actual_state.grid.dx,
+            actual_state.grid.dy,
+            5.0,
+        )
+
+        np.testing.assert_allclose(
+            actual_state.hydraulic.qx,
+            expected_state.hydraulic.qx,
+        )
+        np.testing.assert_allclose(
+            actual_state.hydraulic.qy,
+            expected_state.hydraulic.qy,
+        )
 
     def test_apply_rainfall_forcing_adds_depth_only_to_valid_storm_cells(self) -> None:
         grid = RasterGrid(


### PR DESCRIPTION
## Summary

Closes #25.

This compiles the outgoing-flux limiter directly as `limit_outgoing_fluxes`, so the timestep no longer spends this stage building `outgoing_depth`, `scale`, and several `np.where` arrays in Python/NumPy expression form.

## Changes

- Change `water_timestep` to call the compiled `limit_outgoing_fluxes` kernel directly with the depth, qx/qy, valid-cell mask, grid spacing, and timestep arrays/scalars.
- Remove the extra `limit_outgoing_fluxes_numba` and `limit_outgoing_fluxes_numpy` names.
- Add a direct limiter test covering interior and boundary flux sign conventions with hand-computed expected values.

## Validation

- `git diff --check`
- `python -m compileall -q src tests`
- `PYTHONPATH=src python -m unittest tests.test_config`

`PYTHONPATH=src python -m unittest tests.test_engine` was attempted, but this bundled local runtime is missing dependencies such as `tqdm` and `numba`, so the engine test module cannot import here.