### PR TITLE
Render snapshots asynchronously

### DIFF
--- a/src/nefas/engine.py
+++ b/src/nefas/engine.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 from collections.abc import Iterator
+from concurrent.futures import Future, ProcessPoolExecutor
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
@@ -26,12 +27,16 @@ from matplotlib import pyplot as plt
 LOGGER = logging.getLogger(__name__)
 GRAVITY_METERS_PER_SECOND_SQUARED = 9.80665
 DRY_DEPTH_METERS = 0.001
+MAX_PENDING_SNAPSHOT_RENDERS = 10
 WATER_DEPTH_ALPHA = 0.82
 WATER_DEPTH_COLORMAP = LinearSegmentedColormap.from_list(
     "nefas_water_depth",
     ("#d8fbff", "#86d4ff", "#1f8be3", "#08306b"),
 )
 WATER_DEPTH_COLORMAP.set_bad((0, 0, 0, 0))
+
+_SNAPSHOT_RENDER_GRID: RasterGrid | None = None
+_SNAPSHOT_RENDER_STORM_MASK: np.ndarray | None = None
 
 
 @dataclass(frozen=True)
@@ -41,6 +46,42 @@ class SimulationRunResult:
     snapshot_directory: Path
     snapshots: tuple[Path, ...]
     duration_seconds: float
+
+
+@dataclass
+class SnapshotRenderQueue:
+    """Bounded asynchronous snapshot renderer."""
+
+    executor: ProcessPoolExecutor
+    pending: list[Future[Path]]
+
+    def submit(
+        self,
+        *,
+        depth: np.ndarray,
+        path: Path,
+        elapsed_minutes: float,
+        max_depth_meters: float | None,
+    ) -> Path:
+        """Queue a render job and apply backpressure when too many are pending."""
+        while len(self.pending) >= MAX_PENDING_SNAPSHOT_RENDERS:
+            self.pending.pop(0).result()
+
+        self.pending.append(
+            self.executor.submit(
+                render_snapshot_from_context,
+                depth.copy(),
+                path,
+                elapsed_minutes,
+                max_depth_meters,
+            )
+        )
+        return path
+
+    def wait(self) -> None:
+        """Wait for all queued render jobs, surfacing worker exceptions."""
+        while self.pending:
+            self.pending.pop(0).result()
 
 
 def run_simulation(
@@ -62,50 +103,62 @@ def run_simulation(
     )
     snapshot_directory.mkdir(parents=True, exist_ok=True)
 
-    snapshots = [
-        write_snapshot(
-            grid,
+    with ProcessPoolExecutor(
+        max_workers=1,
+        initializer=initialize_snapshot_renderer,
+        initargs=(
+            grid.elevation,
+            grid.dx,
+            grid.dy,
+            grid.valid_cells,
             storm_mask,
-            state,
-            snapshot_directory,
-            index=0,
-            max_depth_meters=config.output.snapshots.max_depth_meters,
-        )
-    ]
-    next_snapshot_seconds = min(snapshot_interval_seconds, duration_seconds)
-    with simulation_progress(duration_seconds) as progress:
-        while state.hydraulic.time_seconds < duration_seconds:
-            previous_time_seconds = state.hydraulic.time_seconds
-            dt_seconds = timestep_duration_seconds(
-                current_time_seconds=state.hydraulic.time_seconds,
-                duration_seconds=duration_seconds,
-                next_snapshot_seconds=next_snapshot_seconds,
-                nominal_time_step_seconds=effective_time_step_seconds(config),
-            )
-            run_timestep(
+        ),
+    ) as executor:
+        render_queue = SnapshotRenderQueue(executor=executor, pending=[])
+        snapshots = [
+            queue_snapshot(
+                render_queue,
                 state,
-                config.rainfall,
-                storm_mask,
-                dt_seconds,
+                snapshot_directory,
+                index=0,
+                max_depth_meters=config.output.snapshots.max_depth_meters,
             )
-            progress.update(state.hydraulic.time_seconds - previous_time_seconds)
+        ]
+        next_snapshot_seconds = min(snapshot_interval_seconds, duration_seconds)
+        with simulation_progress(duration_seconds) as progress:
+            while state.hydraulic.time_seconds < duration_seconds:
+                previous_time_seconds = state.hydraulic.time_seconds
+                dt_seconds = timestep_duration_seconds(
+                    current_time_seconds=state.hydraulic.time_seconds,
+                    duration_seconds=duration_seconds,
+                    next_snapshot_seconds=next_snapshot_seconds,
+                    nominal_time_step_seconds=effective_time_step_seconds(config),
+                )
+                run_timestep(
+                    state,
+                    config.rainfall,
+                    storm_mask,
+                    dt_seconds,
+                )
+                progress.update(state.hydraulic.time_seconds - previous_time_seconds)
 
-            if state.hydraulic.time_seconds >= next_snapshot_seconds:
-                snapshots.append(
-                    write_snapshot(
-                        grid,
-                        storm_mask,
-                        state,
-                        snapshot_directory,
-                        index=len(snapshots),
-                        max_depth_meters=config.output.snapshots.max_depth_meters,
+                if state.hydraulic.time_seconds >= next_snapshot_seconds:
+                    snapshots.append(
+                        queue_snapshot(
+                            render_queue,
+                            state,
+                            snapshot_directory,
+                            index=len(snapshots),
+                            max_depth_meters=config.output.snapshots.max_depth_meters,
+                        )
                     )
-                )
-                progress.set_postfix(snapshots=len(snapshots))
-                next_snapshot_seconds = min(
-                    next_snapshot_seconds + snapshot_interval_seconds,
-                    duration_seconds,
-                )
+                    progress.set_postfix(snapshots=len(snapshots))
+                    next_snapshot_seconds = min(
+                        next_snapshot_seconds + snapshot_interval_seconds,
+                        duration_seconds,
+                    )
+
+        render_queue.wait()
 
     LOGGER.info(
         "Wrote %s simulation snapshots to %s",
@@ -117,6 +170,45 @@ def run_simulation(
         snapshots=tuple(snapshots),
         duration_seconds=state.hydraulic.time_seconds,
     )
+
+
+def initialize_snapshot_renderer(
+    elevation: np.ndarray,
+    dx: float,
+    dy: float,
+    valid_cells: np.ndarray,
+    storm_mask: np.ndarray,
+) -> None:
+    """Initialize read-only render context inside a worker process."""
+    global _SNAPSHOT_RENDER_GRID, _SNAPSHOT_RENDER_STORM_MASK
+    _SNAPSHOT_RENDER_GRID = RasterGrid(
+        elevation=elevation,
+        dx=dx,
+        dy=dy,
+        valid_cells=valid_cells,
+    )
+    _SNAPSHOT_RENDER_STORM_MASK = storm_mask
+
+
+def render_snapshot_from_context(
+    depth: np.ndarray,
+    path: Path,
+    elapsed_minutes: float,
+    max_depth_meters: float | None,
+) -> Path:
+    """Render a queued snapshot using worker-local static context."""
+    if _SNAPSHOT_RENDER_GRID is None or _SNAPSHOT_RENDER_STORM_MASK is None:
+        raise RuntimeError("Snapshot renderer has not been initialized.")
+
+    render_snapshot(
+        _SNAPSHOT_RENDER_GRID,
+        _SNAPSHOT_RENDER_STORM_MASK,
+        depth,
+        path,
+        elapsed_minutes=elapsed_minutes,
+        max_depth_meters=max_depth_meters,
+    )
+    return path
 
 
 def resolve_snapshot_directory(snapshot_directory: Path, workspace: Path) -> Path:
@@ -661,6 +753,23 @@ def update_diagnostics(state: SimulationState, dt_seconds: float) -> None:
     newly_wet = np.isnan(state.diagnostics.arrival_time) & wet_cells
     state.diagnostics.arrival_time[newly_wet] = state.hydraulic.time_seconds
     state.diagnostics.flood_duration[wet_cells] += dt_seconds
+
+
+def queue_snapshot(
+    render_queue: SnapshotRenderQueue,
+    state: SimulationState,
+    snapshot_directory: Path,
+    index: int,
+    max_depth_meters: float | None = None,
+) -> Path:
+    """Queue one simulation snapshot render and return its eventual path."""
+    snapshot = snapshot_directory / f"snapshot_{index:04d}.png"
+    return render_queue.submit(
+        depth=state.hydraulic.depth,
+        path=snapshot,
+        elapsed_minutes=state.hydraulic.time_seconds / 60,
+        max_depth_meters=max_depth_meters,
+    )
 
 
 def write_snapshot(

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -18,6 +18,8 @@ from nefas.config import (
     SnapshotConfig,
 )
 from nefas.engine import (
+    MAX_PENDING_SNAPSHOT_RENDERS,
+    SnapshotRenderQueue,
     WATER_DEPTH_ALPHA,
     WATER_DEPTH_COLORMAP,
     add_rainfall_depth,
@@ -35,6 +37,25 @@ from nefas.engine import (
     water_timestep,
 )
 from nefas.simulation import RasterGrid, SimulationState
+
+
+class FakeFuture:
+    def __init__(self, result: Path) -> None:
+        self._result = result
+        self.result_calls = 0
+
+    def result(self) -> Path:
+        self.result_calls += 1
+        return self._result
+
+
+class FakeExecutor:
+    def __init__(self) -> None:
+        self.submissions = []
+
+    def submit(self, function, *args):
+        self.submissions.append((function, args))
+        return FakeFuture(args[1])
 
 
 def make_simulation_config(
@@ -68,6 +89,30 @@ def make_simulation_config(
 
 
 class EngineTests(unittest.TestCase):
+    def test_snapshot_render_queue_copies_depth_and_limits_pending_jobs(self) -> None:
+        executor = FakeExecutor()
+        oldest_future = FakeFuture(Path("oldest.png"))
+        render_queue = SnapshotRenderQueue(
+            executor=executor,
+            pending=[oldest_future]
+            + [FakeFuture(Path(f"snapshot_{index}.png")) for index in range(9)],
+        )
+        depth = np.array([[1.0]], dtype=np.float64)
+
+        snapshot = render_queue.submit(
+            depth=depth,
+            path=Path("snapshot_0010.png"),
+            elapsed_minutes=10,
+            max_depth_meters=2.0,
+        )
+        depth[0, 0] = 99.0
+
+        self.assertEqual(snapshot, Path("snapshot_0010.png"))
+        self.assertEqual(oldest_future.result_calls, 1)
+        self.assertEqual(len(render_queue.pending), MAX_PENDING_SNAPSHOT_RENDERS)
+        submitted_depth = executor.submissions[0][1][0]
+        np.testing.assert_allclose(submitted_depth, np.array([[1.0]]))
+
     def test_timestep_stops_at_snapshot_and_event_end(self) -> None:
         self.assertEqual(
             timestep_duration_seconds(


### PR DESCRIPTION
## Summary

Closes #27.

This moves snapshot rendering out of the main simulation loop and into a bounded background process queue. The simulation now queues snapshot renders and continues stepping while the worker process renders PNGs.

## Changes

- Add `SnapshotRenderQueue` with `MAX_PENDING_SNAPSHOT_RENDERS = 10` backpressure.
- Initialize a persistent render worker with the static render context: elevation, cell spacing, valid-cell mask, and storm mask.
- Queue only `depth.copy()`, output path, elapsed minutes, and depth scale per snapshot job.
- Wait for all pending renders before returning `SimulationRunResult`, surfacing worker exceptions through `future.result()`.
- Add a queue unit test verifying depth is copied and pending jobs are capped.

A note on process memory: the worker process has its own memory space. Static render context is copied once into the worker at startup, and each snapshot job copies only the depth raster plus small metadata. The queued depth copies are bounded by the pending limit.

## Validation

- `git diff --check`
- `python -m compileall -q src tests`
- `PYTHONPATH=src python -m unittest tests.test_config`

`PYTHONPATH=src python -m unittest tests.test_engine` was attempted, but this bundled local runtime is missing dependencies such as `tqdm`, so the engine test module cannot import here.